### PR TITLE
Feature/fixing mage rotation

### DIFF
--- a/playerbot/strategy/mage/FireMageStrategy.cpp
+++ b/playerbot/strategy/mage/FireMageStrategy.cpp
@@ -9,6 +9,11 @@ void FireMageStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
 {
     GenericMageStrategy::InitTriggers(triggers);
 
+	//Add living Bomb first
+	triggers.push_back(new TriggerNode(
+		"living bomb",
+		NextAction::array(0, new NextAction("living bomb", 60.0f), NULL)));
+
     // cast fireball as default
     triggers.push_back(new TriggerNode(
         "cast fireball",
@@ -22,7 +27,7 @@ void FireMageStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
     // always use pyroblast, when hotstreak is available
     triggers.push_back(new TriggerNode(
         "hot streak",
-        NextAction::array(0, new NextAction("pyroblast", 25.0f), NULL)));
+        NextAction::array(0, new NextAction("pyroblast", 250.0f), NULL)));
 
     // use combustion boost, when required
     triggers.push_back(new TriggerNode(
@@ -32,7 +37,8 @@ void FireMageStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
     // flee action (applies disorientation), when enemy is 2 close 2 you
     triggers.push_back(new TriggerNode(
         "enemy too close for spell",
-        NextAction::array(0, new NextAction("dragon's breath", 70.0f), NULL)));
+        NextAction::array(0, new NextAction("dragon's breath", 30.0f), NULL)));
+
 }
 
 void FireMageAoeStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
@@ -41,8 +47,9 @@ void FireMageAoeStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
         "medium aoe",
         NextAction::array(0, new NextAction("flamestrike", 20.0f), NULL)));
 
-    triggers.push_back(new TriggerNode(
-        "living bomb",
-        NextAction::array(0, new NextAction("living bomb", 25.0f), NULL)));
+	//Add living Bomb first
+	triggers.push_back(new TriggerNode(
+		"living bomb",
+		NextAction::array(0, new NextAction("living bomb", 60.0f), NULL)));
 }
 

--- a/playerbot/strategy/mage/FireMageStrategy.cpp
+++ b/playerbot/strategy/mage/FireMageStrategy.cpp
@@ -9,18 +9,27 @@ void FireMageStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
 {
     GenericMageStrategy::InitTriggers(triggers);
 
+    // cast fireball as default
     triggers.push_back(new TriggerNode(
         "cast fireball",
         NextAction::array(0, new NextAction("fireball", 10.0f), NULL)));
 
+    // initiate with scorch or reapply it, when the advanced scorch effect is not applied
+    triggers.push_back(new TriggerNode(
+        "improved scorch",
+        NextAction::array(0, new NextAction("scorch", 20.0f), NULL)));
+
+    // always use pyroblast, when hotstreak is available
     triggers.push_back(new TriggerNode(
         "hot streak",
         NextAction::array(0, new NextAction("pyroblast", 25.0f), NULL)));
 
+    // use combustion boost, when required
     triggers.push_back(new TriggerNode(
         "combustion",
         NextAction::array(0, new NextAction("combustion", 50.0f), NULL)));
 
+    // flee action (applies disorientation), when enemy is 2 close 2 you
     triggers.push_back(new TriggerNode(
         "enemy too close for spell",
         NextAction::array(0, new NextAction("dragon's breath", 70.0f), NULL)));

--- a/playerbot/strategy/mage/FireMageStrategy.cpp
+++ b/playerbot/strategy/mage/FireMageStrategy.cpp
@@ -5,18 +5,13 @@
 
 using namespace ai;
 
-NextAction** FireMageStrategy::getDefaultActions()
-{
-    return NextAction::array(0, new NextAction("scorch", 7.0f), new NextAction("fireball", 6.0f), new NextAction("fire blast", 5.0f), NULL);
-}
-
 void FireMageStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
 {
     GenericMageStrategy::InitTriggers(triggers);
 
     triggers.push_back(new TriggerNode(
-        "pyroblast",
-        NextAction::array(0, new NextAction("pyroblast", 10.0f), NULL)));
+        "cast fireball",
+        NextAction::array(0, new NextAction("fireball", 10.0f), NULL)));
 
     triggers.push_back(new TriggerNode(
         "hot streak",

--- a/playerbot/strategy/mage/FireMageStrategy.h
+++ b/playerbot/strategy/mage/FireMageStrategy.h
@@ -13,7 +13,6 @@ namespace ai
     public:
         virtual void InitTriggers(std::list<TriggerNode*> &triggers);
         virtual string getName() { return "fire"; }
-        virtual NextAction** getDefaultActions();
     };
 
     class FireMageAoeStrategy : public CombatStrategy

--- a/playerbot/strategy/mage/MageAiObjectContext.cpp
+++ b/playerbot/strategy/mage/MageAiObjectContext.cpp
@@ -111,7 +111,7 @@ namespace ai
                 creators["presence of mind"] = &TriggerFactoryInternal::presence_of_mind;
                 creators["fire ward"] = &TriggerFactoryInternal::fire_ward;
                 creators["frost ward"] = &TriggerFactoryInternal::frost_ward;
-
+                creators["cast fireball"] = &TriggerFactoryInternal::cast_fireball;
             }
 
         private:
@@ -136,6 +136,7 @@ namespace ai
             static Trigger* missile_barrage(PlayerbotAI* ai) { return new MissileBarrageTrigger(ai); }
             static Trigger* arcane_blast(PlayerbotAI* ai) { return new ArcaneBlastTrigger(ai); }
             static Trigger* counterspell_enemy_healer(PlayerbotAI* ai) { return new CounterspellEnemyHealerTrigger(ai); }
+            static Trigger* cast_fireball(PlayerbotAI* ai) { return new SpellCanBeCastTrigger(ai, "fireball"); }
         };
     };
 };

--- a/playerbot/strategy/mage/MageAiObjectContext.cpp
+++ b/playerbot/strategy/mage/MageAiObjectContext.cpp
@@ -112,6 +112,7 @@ namespace ai
                 creators["fire ward"] = &TriggerFactoryInternal::fire_ward;
                 creators["frost ward"] = &TriggerFactoryInternal::frost_ward;
                 creators["cast fireball"] = &TriggerFactoryInternal::cast_fireball;
+                creators["improved scorch"] = &TriggerFactoryInternal::improved_scorch;
             }
 
         private:
@@ -137,6 +138,7 @@ namespace ai
             static Trigger* arcane_blast(PlayerbotAI* ai) { return new ArcaneBlastTrigger(ai); }
             static Trigger* counterspell_enemy_healer(PlayerbotAI* ai) { return new CounterspellEnemyHealerTrigger(ai); }
             static Trigger* cast_fireball(PlayerbotAI* ai) { return new SpellCanBeCastTrigger(ai, "fireball"); }
+            static Trigger* improved_scorch(PlayerbotAI* ai) { return new ImprovedScorchTrigger(ai); }
         };
     };
 };

--- a/playerbot/strategy/mage/MageTriggers.h
+++ b/playerbot/strategy/mage/MageTriggers.h
@@ -41,9 +41,9 @@ namespace ai
         PyroblastTrigger(PlayerbotAI* ai) : DebuffTrigger(ai, "pyroblast") {}
     };
 
-    class HotStreakTrigger : public HasAuraTrigger {
+    class HotStreakTrigger : public SpellCanBeCastInstantTrigger {
     public:
-        HotStreakTrigger(PlayerbotAI* ai) : HasAuraTrigger(ai, "hot streak") {}
+        HotStreakTrigger(PlayerbotAI* ai) : SpellCanBeCastInstantTrigger(ai, "pyroblast") {}
     };
 
     class MissileBarrageTrigger : public HasAuraTrigger {

--- a/playerbot/strategy/mage/MageTriggers.h
+++ b/playerbot/strategy/mage/MageTriggers.h
@@ -26,10 +26,7 @@ namespace ai
         virtual bool IsActive();
     };
 
-    class LivingBombTrigger : public DebuffTrigger {
-    public:
-        LivingBombTrigger(PlayerbotAI* ai) : DebuffTrigger(ai, "living bomb") {}
-	};
+	MY_DEBUFF_TRIGGER(LivingBombTrigger, "living bomb");
 
     class FireballTrigger : public DebuffTrigger {
     public:

--- a/playerbot/strategy/mage/MageTriggers.h
+++ b/playerbot/strategy/mage/MageTriggers.h
@@ -115,4 +115,10 @@ namespace ai
     public:
         PresenceOfMindTrigger(PlayerbotAI* ai) : BuffTrigger(ai, "presence of mind") {}
     };
+
+    class ImprovedScorchTrigger : public DebuffTrigger
+    {
+    public:
+        ImprovedScorchTrigger(PlayerbotAI* ai) : DebuffTrigger(ai, "improved scorch") {}
+    };
 }


### PR DESCRIPTION
Fixes the fire mage rotation by 
* only allow pyroblast on hot streak trigger (changed from aura to instant cast)
* cast fireball as default cast
* remove all default actions
* add scorch to rotation, since it apply improved scorch on the enemy, which increases crit %