### PR TITLE
Mage bots conjuring refreshments

### DIFF
--- a/playerbot/strategy/actions/ActionContext.h
+++ b/playerbot/strategy/actions/ActionContext.h
@@ -133,6 +133,7 @@ namespace ai
             creators["try emergency"] = &ActionContext::try_emergency;
             creators["give food"] = &ActionContext::give_food;
             creators["give water"] = &ActionContext::give_water;
+            creators["give refreshment"] = &ActionContext::give_refreshment;
             creators["mount"] = &ActionContext::mount;
             creators["war stomp"] = &ActionContext::war_stomp;
             creators["auto talents"] = &ActionContext::auto_talents;
@@ -178,6 +179,7 @@ namespace ai
         }
 
     private:
+        static Action* give_refreshment(PlayerbotAI* ai) { return new GiveRefreshmentAction(ai); }
         static Action* give_water(PlayerbotAI* ai) { return new GiveWaterAction(ai); }
         static Action* give_food(PlayerbotAI* ai) { return new GiveFoodAction(ai); }
         static Action* ra(PlayerbotAI* ai) { return new RemoveAuraAction(ai); }

--- a/playerbot/strategy/actions/GenericSpellActions.cpp
+++ b/playerbot/strategy/actions/GenericSpellActions.cpp
@@ -6,7 +6,7 @@ using namespace ai;
 
 bool CastSpellAction::Execute(Event event)
 {
-	if (spell == "conjure food" || spell == "conjure water")
+	if (spell == "conjure food" || spell == "conjure water" || spell == "conjure refreshment")
 	{
 		//uint32 id = AI_VALUE2(uint32, "spell id", spell);
 		//if (!id)

--- a/playerbot/strategy/actions/GiveItemAction.cpp
+++ b/playerbot/strategy/actions/GiveItemAction.cpp
@@ -70,3 +70,8 @@ Unit* GiveWaterAction::GetTarget()
 {
     return AI_VALUE(Unit*, "party member without water");
 }
+
+Unit* GiveRefreshmentAction::GetTarget()
+{
+    return AI_VALUE(Unit*, "party member without refreshment");
+}

--- a/playerbot/strategy/actions/GiveItemAction.h
+++ b/playerbot/strategy/actions/GiveItemAction.h
@@ -31,4 +31,11 @@ namespace ai
         virtual Unit* GetTarget();
     };
 
+    class GiveRefreshmentAction : public GiveItemAction
+    {
+    public:
+        GiveRefreshmentAction(PlayerbotAI* ai) : GiveItemAction(ai, "give refreshment", "conjured refreshment") {}
+        virtual Unit* GetTarget();
+    };
+
 }

--- a/playerbot/strategy/actions/InventoryAction.cpp
+++ b/playerbot/strategy/actions/InventoryAction.cpp
@@ -210,6 +210,13 @@ list<Item*> InventoryAction::parseItems(string text, IterateItemsMask mask, bool
         return result;
     }
 
+    if (text == "conjured refreshment")
+    {
+        FindFoodVisitor visitor(bot, 11, true);
+        IterateItems(&visitor, ITERATE_ITEMS_IN_BAGS);
+        found.insert(visitor.GetResult().begin(), visitor.GetResult().end());
+    }
+
     if (text == "food" || text == "conjured food")
     {
         FindFoodVisitor visitor(bot, 11, (text == "conjured food"));
@@ -267,7 +274,7 @@ list<Item*> InventoryAction::parseItems(string text, IterateItemsMask mask, bool
     {
         FindRecipeVisitor visitor(bot);
         IterateItems(&visitor, ITERATE_ITEMS_IN_BAGS);
-        found.insert(visitor.GetResult().begin(), visitor.GetResult().end());        
+        found.insert(visitor.GetResult().begin(), visitor.GetResult().end());
     }
 
     if (text == "quest")

--- a/playerbot/strategy/mage/GenericMageNonCombatStrategy.cpp
+++ b/playerbot/strategy/mage/GenericMageNonCombatStrategy.cpp
@@ -51,6 +51,10 @@ void GenericMageNonCombatStrategy::InitTriggers(std::list<TriggerNode*> &trigger
         "arcane intellect",
         NextAction::array(0, new NextAction("arcane intellect", 21.0f), NULL)));
 
+    triggers.push_back(new TriggerNode(
+        "no refreshment",
+        NextAction::array(0, new NextAction("conjure refreshment", 17.0f), NULL)));
+
 	triggers.push_back(new TriggerNode(
 		"no drink",
 		NextAction::array(0, new NextAction("conjure water", 16.0f), NULL)));
@@ -83,6 +87,10 @@ void MageBuffStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
     triggers.push_back(new TriggerNode(
         "arcane intellect on party",
         NextAction::array(0, new NextAction("arcane intellect on party", 20.0f), NULL)));
+
+    triggers.push_back(new TriggerNode(
+        "give refreshment",
+        NextAction::array(0, new NextAction("give refreshment", 15.0f), NULL)));
 
     triggers.push_back(new TriggerNode(
         "give water",

--- a/playerbot/strategy/mage/MageActions.h
+++ b/playerbot/strategy/mage/MageActions.h
@@ -143,6 +143,12 @@ namespace ai
 		CastConjureWaterAction(PlayerbotAI* ai) : CastBuffSpellAction(ai, "conjure water") {}
 	};
 
+    class CastConjureRefreshmentAction : public CastBuffSpellAction
+    {
+    public:
+        CastConjureRefreshmentAction(PlayerbotAI* ai) : CastBuffSpellAction(ai, "conjure refreshment") {}
+    };
+
 	class CastIceBlockAction : public CastBuffSpellAction
     {
 	public:

--- a/playerbot/strategy/mage/MageAiObjectContext.cpp
+++ b/playerbot/strategy/mage/MageAiObjectContext.cpp
@@ -161,6 +161,7 @@ namespace ai
                 creators["arcane intellect on party"] = &AiObjectContextInternal::arcane_intellect_on_party;
                 creators["conjure water"] = &AiObjectContextInternal::conjure_water;
                 creators["conjure food"] = &AiObjectContextInternal::conjure_food;
+                creators["conjure refreshment"] = &AiObjectContextInternal::conjure_refreshment;
                 creators["molten armor"] = &AiObjectContextInternal::molten_armor;
                 creators["mage armor"] = &AiObjectContextInternal::mage_armor;
                 creators["ice armor"] = &AiObjectContextInternal::ice_armor;
@@ -208,6 +209,7 @@ namespace ai
             static Action* arcane_intellect_on_party(PlayerbotAI* ai) { return new CastArcaneIntellectOnPartyAction(ai); }
             static Action* conjure_water(PlayerbotAI* ai) { return new CastConjureWaterAction(ai); }
             static Action* conjure_food(PlayerbotAI* ai) { return new CastConjureFoodAction(ai); }
+            static Action* conjure_refreshment(PlayerbotAI* ai) { return new CastConjureRefreshmentAction(ai); }
             static Action* molten_armor(PlayerbotAI* ai) { return new CastMoltenArmorAction(ai); }
             static Action* mage_armor(PlayerbotAI* ai) { return new CastMageArmorAction(ai); }
             static Action* ice_armor(PlayerbotAI* ai) { return new CastIceArmorAction(ai); }

--- a/playerbot/strategy/triggers/GenericTriggers.h
+++ b/playerbot/strategy/triggers/GenericTriggers.h
@@ -201,16 +201,22 @@ namespace ai
         float range;
     };
 
+    class NoRefreshmentTrigger : public Trigger {
+    public:
+        NoRefreshmentTrigger(PlayerbotAI* ai) : Trigger(ai, "no refreshment trigger") {}
+        virtual bool IsActive() { return AI_VALUE2(list<Item*>, "inventory items", "conjured refreshment").empty(); }
+    };
+
     class NoFoodTrigger : public Trigger {
     public:
         NoFoodTrigger(PlayerbotAI* ai) : Trigger(ai, "no food trigger") {}
-        virtual bool IsActive() { return AI_VALUE2(list<Item*>, "inventory items", "conjured food").empty(); }
+        virtual bool IsActive() { return AI_VALUE2(list<Item*>, "inventory items", "conjured food").empty() && AI_VALUE2(list<Item*>, "inventory items", "conjured refreshment").empty(); }
     };
 
     class NoDrinkTrigger : public Trigger {
     public:
         NoDrinkTrigger(PlayerbotAI* ai) : Trigger(ai, "no drink trigger") {}
-        virtual bool IsActive() { return AI_VALUE2(list<Item*>, "inventory items", "conjured water").empty(); }
+        virtual bool IsActive() { return AI_VALUE2(list<Item*>, "inventory items", "conjured water").empty() && AI_VALUE2(list<Item*>, "inventory items", "conjured refreshment").empty(); }
     };
 
     class RangeAoeTrigger : public AoeTrigger
@@ -767,7 +773,7 @@ namespace ai
     public:
         virtual bool IsActive()
         {
-            return AI_VALUE(Unit*, "party member without food") && AI_VALUE2(uint32, "item count", item);
+            return AI_VALUE(Unit*, "party member without food") && AI_VALUE(Unit*, "party member without refreshment") && AI_VALUE2(uint32, "item count", item);
         }
     };
 
@@ -778,7 +784,18 @@ namespace ai
     public:
         virtual bool IsActive()
         {
-            return AI_VALUE(Unit*, "party member without water") && AI_VALUE2(uint32, "item count", item);
+            return AI_VALUE(Unit*, "party member without water") && AI_VALUE(Unit*, "party member without refreshment") && AI_VALUE2(uint32, "item count", item);
+        }
+    };
+
+    class GiveRefreshmentTrigger : public GiveItemTrigger
+    {
+    public:
+        GiveRefreshmentTrigger(PlayerbotAI* ai) : GiveItemTrigger(ai, "give refreshment", "conjured refreshment") {}
+    public:
+        virtual bool IsActive()
+        {
+            return AI_VALUE(Unit*, "party member without refreshment") && AI_VALUE2(uint32, "item count", item);
         }
     };
 

--- a/playerbot/strategy/triggers/TriggerContext.h
+++ b/playerbot/strategy/triggers/TriggerContext.h
@@ -79,7 +79,7 @@ namespace ai
             creators["range aoe"] = &TriggerContext::RangeAoe;
             creators["light aoe"] = &TriggerContext::LightAoe;
             creators["medium aoe"] = &TriggerContext::MediumAoe;
-            creators["high aoe"] = &TriggerContext::HighAoe;            
+            creators["high aoe"] = &TriggerContext::HighAoe;
 
             creators["enemy out of melee"] = &TriggerContext::EnemyOutOfMelee;
             creators["enemy out of spell"] = &TriggerContext::EnemyOutOfSpell;
@@ -102,6 +102,7 @@ namespace ai
             creators["no possible grind target"] = &TriggerContext::no_possible_grind_target;
             creators["possible adds"] = &TriggerContext::possible_adds;
 
+            creators["no refreshment"] = &TriggerContext::no_refreshment;
             creators["no drink"] = &TriggerContext::no_drink;
             creators["no food"] = &TriggerContext::no_food;
 
@@ -137,6 +138,7 @@ namespace ai
 
             creators["give food"] = &TriggerContext::give_food;
             creators["give water"] = &TriggerContext::give_water;
+            creators["give refreshment"] = &TriggerContext::give_refreshment;
 
             creators["bg waiting"] = &TriggerContext::bg_waiting;
             creators["bg active"] = &TriggerContext::bg_active;
@@ -183,6 +185,7 @@ namespace ai
         static Trigger* player_is_in_battleground_no_flag(PlayerbotAI *ai) { return new PlayerIsInBattlegroundWithoutFlag(ai); }
         static Trigger* give_food(PlayerbotAI* ai) { return new GiveFoodTrigger(ai); }
         static Trigger* give_water(PlayerbotAI* ai) { return new GiveWaterTrigger(ai); }
+        static Trigger* give_refreshment(PlayerbotAI* ai) { return new GiveRefreshmentTrigger(ai); }
         static Trigger* no_rti(PlayerbotAI* ai) { return new NoRtiTrigger(ai); }
         static Trigger* _return(PlayerbotAI* ai) { return new ReturnTrigger(ai); }
         static Trigger* sit(PlayerbotAI* ai) { return new SitTrigger(ai); }
@@ -190,7 +193,7 @@ namespace ai
         static Trigger* near_rpg_target(PlayerbotAI* ai) { return new NearRpgTargetTrigger(ai); }
         static Trigger* no_rpg_target(PlayerbotAI* ai) { return new NoRpgTargetTrigger(ai); }
         static Trigger* far_from_travel_target(PlayerbotAI* ai) { return new FarFromTravelTargetTrigger(ai); }
-        static Trigger* no_travel_target(PlayerbotAI* ai) { return new NoTravelTargetTrigger(ai); }		
+        static Trigger* no_travel_target(PlayerbotAI* ai) { return new NoTravelTargetTrigger(ai); }
         static Trigger* collision(PlayerbotAI* ai) { return new CollisionTrigger(ai); }
         static Trigger* lfg_proposal_active(PlayerbotAI* ai) { return new LfgProposalActiveTrigger(ai); }
         static Trigger* unknown_dungeon(PlayerbotAI* ai) { return new UnknownDungeonTrigger(ai); }
@@ -215,10 +218,11 @@ namespace ai
         static Trigger* outnumbered(PlayerbotAI* ai) { return new OutNumberedTrigger(ai); }
         static Trigger* no_drink(PlayerbotAI* ai) { return new NoDrinkTrigger(ai); }
         static Trigger* no_food(PlayerbotAI* ai) { return new NoFoodTrigger(ai); }
+        static Trigger* no_refreshment(PlayerbotAI* ai) { return new NoRefreshmentTrigger(ai); }
         static Trigger* RangeAoe(PlayerbotAI* ai) { return new RangeAoeTrigger(ai); }
         static Trigger* LightAoe(PlayerbotAI* ai) { return new LightAoeTrigger(ai); }
         static Trigger* MediumAoe(PlayerbotAI* ai) { return new MediumAoeTrigger(ai); }
-        static Trigger* HighAoe(PlayerbotAI* ai) { return new HighAoeTrigger(ai); }        
+        static Trigger* HighAoe(PlayerbotAI* ai) { return new HighAoeTrigger(ai); }
         static Trigger* LoseAggro(PlayerbotAI* ai) { return new LoseAggroTrigger(ai); }
         static Trigger* HasAggro(PlayerbotAI* ai) { return new HasAggroTrigger(ai); }
         static Trigger* HasAreaDebuff(PlayerbotAI* ai) { return new HasAreaDebuffTrigger(ai); }
@@ -278,12 +282,12 @@ namespace ai
         static Trigger* falling_far(PlayerbotAI* ai) { return new IsFallingFarTrigger(ai); }
         static Trigger* movement_stuck(PlayerbotAI* ai) { return new MovementStuckTrigger(ai); }
         static Trigger* location_stuck(PlayerbotAI* ai) { return new LocationStuckTrigger(ai); }
-        static Trigger* player_wants_in_bg(PlayerbotAI* ai) { return new PlayerWantsInBattlegroundTrigger(ai); } 
-        static Trigger* use_trinket(PlayerbotAI* ai) { return new UseTrinketTrigger(ai); } 
+        static Trigger* player_wants_in_bg(PlayerbotAI* ai) { return new PlayerWantsInBattlegroundTrigger(ai); }
+        static Trigger* use_trinket(PlayerbotAI* ai) { return new UseTrinketTrigger(ai); }
         static Trigger* damage_stop(PlayerbotAI* ai) { return new DamageStopTrigger(ai); }
 
         static Trigger* petition_signed(PlayerbotAI* ai) { return new PetitionTurnInTrigger(ai); }
-        static Trigger* buy_tabard(PlayerbotAI* ai) { return new BuyTabardTrigger(ai); }        
+        static Trigger* buy_tabard(PlayerbotAI* ai) { return new BuyTabardTrigger(ai); }
         static Trigger* leave_large_guild(PlayerbotAI* ai) { return new LeaveLargeGuildTrigger(ai); }
     };
 };

--- a/playerbot/strategy/values/PartyMemberWithoutItemValue.cpp
+++ b/playerbot/strategy/values/PartyMemberWithoutItemValue.cpp
@@ -103,6 +103,33 @@ public:
 
 };
 
+class PlayerWithoutRefreshmentPredicate : public PlayerWithoutItemPredicate
+{
+public:
+    PlayerWithoutRefreshmentPredicate(PlayerbotAI* ai) : PlayerWithoutItemPredicate(ai, "conjured refreshment") {}
+
+public:
+    virtual bool Check(Unit* unit)
+    {
+        if (!PlayerWithoutItemPredicate::Check(unit))
+            return false;
+
+        Player* member = dynamic_cast<Player*>(unit);
+        if (!member)
+            return false;
+
+        uint8 cls = member->getClass();
+        return cls == CLASS_DRUID ||
+            cls == CLASS_HUNTER ||
+            cls == CLASS_PALADIN ||
+            cls == CLASS_PRIEST ||
+            cls == CLASS_SHAMAN ||
+            cls == CLASS_WARLOCK;
+    }
+
+};
+
+
 FindPlayerPredicate* PartyMemberWithoutFoodValue::CreatePredicate()
 {
     return new PlayerWithoutFoodPredicate(ai);
@@ -111,4 +138,9 @@ FindPlayerPredicate* PartyMemberWithoutFoodValue::CreatePredicate()
 FindPlayerPredicate* PartyMemberWithoutWaterValue::CreatePredicate()
 {
     return new PlayerWithoutWaterPredicate(ai);
+}
+
+FindPlayerPredicate* PartyMemberWithoutRefreshmentValue::CreatePredicate()
+{
+    return new PlayerWithoutRefreshmentPredicate(ai);
 }

--- a/playerbot/strategy/values/PartyMemberWithoutItemValue.h
+++ b/playerbot/strategy/values/PartyMemberWithoutItemValue.h
@@ -33,4 +33,13 @@ namespace ai
     protected:
         virtual FindPlayerPredicate* CreatePredicate();
     };
+
+    class PartyMemberWithoutRefreshmentValue : public PartyMemberWithoutItemValue
+    {
+    public:
+        PartyMemberWithoutRefreshmentValue(PlayerbotAI* ai) : PartyMemberWithoutItemValue(ai) {}
+
+    protected:
+        virtual FindPlayerPredicate* CreatePredicate();
+    };
 }

--- a/playerbot/strategy/values/ValueContext.h
+++ b/playerbot/strategy/values/ValueContext.h
@@ -203,7 +203,7 @@ namespace ai
             creators["snare target"] = &ValueContext::snare_target;
             creators["formation"] = &ValueContext::formation;
             creators["stance"] = &ValueContext::stance;
-            creators["item usage"] = &ValueContext::item_usage;            
+            creators["item usage"] = &ValueContext::item_usage;
             creators["speed"] = &ValueContext::speed;
             creators["last said"] = &ValueContext::last_said;
             creators["last emote"] = &ValueContext::last_emote;
@@ -226,6 +226,7 @@ namespace ai
             creators["party member without item"] = &ValueContext::party_member_without_item;
             creators["party member without food"] = &ValueContext::party_member_without_food;
             creators["party member without water"] = &ValueContext::party_member_without_water;
+            creators["party member without refreshment"] = &ValueContext::party_member_without_refreshment;
             creators["death count"] = &ValueContext::death_count;
 
             creators["bg type"] = &ValueContext::bg_type;
@@ -238,19 +239,19 @@ namespace ai
             creators["home bind"] = &ValueContext::home_bind;
             creators["last long move"] = &ValueContext::last_long_move;
 
-            
+
             creators["free quest log slots"] = &ValueContext::free_quest_log_slots;
             creators["dialog status"] = &ValueContext::dialog_status;
             creators["dialog status quest"] = &ValueContext::dialog_status_quest;
             creators["can accept quest npc"] = &ValueContext::can_accept_quest_npc;
             creators["can accept quest low level npc"] = &ValueContext::can_accept_quest_low_level_npc;
             creators["can turn in quest npc"] = &ValueContext::can_turn_in_quest_npc;
-            
+
             creators["money needed for"] = &ValueContext::money_needed_for;
             creators["total money needed for"] = &ValueContext::total_money_needed_for;
-            creators["free money for"] = &ValueContext::free_money_for;            
+            creators["free money for"] = &ValueContext::free_money_for;
             creators["should get money"] = &ValueContext::should_get_money;
-            
+
             creators["should home bind"] = &ValueContext::should_home_bind;
             creators["should repair"] = &ValueContext::should_repair;
             creators["can repair"] = &ValueContext::can_repair;
@@ -281,6 +282,7 @@ namespace ai
         static UntypedValue* bg_role(PlayerbotAI* ai) { return new BgRoleValue(ai); }
         static UntypedValue* arena_type(PlayerbotAI* ai) { return new ArenaTypeValue(ai); }
         static UntypedValue* bg_type(PlayerbotAI* ai) { return new BgTypeValue(ai); }
+        static UntypedValue* party_member_without_refreshment(PlayerbotAI* ai) { return new PartyMemberWithoutRefreshmentValue(ai); }
         static UntypedValue* party_member_without_water(PlayerbotAI* ai) { return new PartyMemberWithoutWaterValue(ai); }
         static UntypedValue* party_member_without_food(PlayerbotAI* ai) { return new PartyMemberWithoutFoodValue(ai); }
         static UntypedValue* party_member_without_item(PlayerbotAI* ai) { return new PartyMemberWithoutItemValue(ai); }
@@ -293,7 +295,7 @@ namespace ai
         static UntypedValue* collision(PlayerbotAI* ai) { return new CollisionValue(ai); }
         static UntypedValue* already_seen_players(PlayerbotAI* ai) { return new AlreadySeenPlayersValue(ai); }
         static UntypedValue* new_player_nearby(PlayerbotAI* ai) { return new NewPlayerNearbyValue(ai); }
-        static UntypedValue* item_usage(PlayerbotAI* ai) { return new ItemUsageValue(ai); }        
+        static UntypedValue* item_usage(PlayerbotAI* ai) { return new ItemUsageValue(ai); }
         static UntypedValue* formation(PlayerbotAI* ai) { return new FormationValue(ai); }
         static UntypedValue* stance(PlayerbotAI* ai) { return new StanceValue(ai); }
         static UntypedValue* mana_save_level(PlayerbotAI* ai) { return new ManaSaveLevelValue(ai); }
@@ -447,7 +449,7 @@ namespace ai
         static UntypedValue* group_and(PlayerbotAI* ai) { return new GroupBoolANDValue(ai); }
         static UntypedValue* group_or(PlayerbotAI* ai) { return new GroupBoolORValue(ai); }
 
-        static UntypedValue* petition_signs(PlayerbotAI* ai) { return new PetitionSignsValue(ai); }        
+        static UntypedValue* petition_signs(PlayerbotAI* ai) { return new PetitionSignsValue(ai); }
 
         static UntypedValue* experience(PlayerbotAI* ai) { return new ExperienceValue(ai); }
         static UntypedValue* go_target_reached(PlayerbotAI* ai) { return new GoTargetReachedValue(ai); }


### PR DESCRIPTION
Allow mage bots to cast "conjure refreshment" instead of conjure food&water, since refreshments are much more effective for anyone > 70

the conjure refreshment will have higher priority compared to the "drink & food" conjuring
In addition, mages will "give refreshements" to other bot party members as well