### PR TITLE
Feature/resto druid

### DIFF
--- a/playerbot/AiFactory.cpp
+++ b/playerbot/AiFactory.cpp
@@ -255,12 +255,18 @@ void AiFactory::AddDefaultCombatStrategies(Player* player, PlayerbotAI* const fa
         case CLASS_DRUID:
             if (tab == 0)
             {
-                engine->addStrategies("caster", "cure", "caster aoe", "threat", "flee", "dps assist", "ranged", "cc", NULL);
+                engine->addStrategies("caster", "cure", "caster aoe", "threat", "flee", "dps assist", "ranged", NULL);
                 if (player->GetLevel() > 19)
                     engine->addStrategy("caster debuff");
+                if (player->GetGroup() == nullptr)
+                    engine->addStrategy("cc");
             }
             else if (tab == 2)
-                engine->addStrategies("heal", "cure", "flee", "dps assist", "ranged", "cc", NULL);
+            {
+                engine->addStrategies("heal", "cure", "flee", "dps assist", "ranged", NULL);
+                if (player->GetGroup() == nullptr)
+                    engine->addStrategy("cc");
+            }
             else
             {
                 engine->removeStrategy("ranged");
@@ -307,7 +313,7 @@ void AiFactory::AddDefaultCombatStrategies(Player* player, PlayerbotAI* const fa
             engine->addStrategy("flee");
             engine->addStrategy("boost");
 
-            
+
             if (player->getClass() == CLASS_DRUID && tab == 2)
             {
                 engine->addStrategies("caster", "caster aoe", NULL);
@@ -383,7 +389,7 @@ void AiFactory::AddDefaultCombatStrategies(Player* player, PlayerbotAI* const fa
 
         if (player->getClass() == CLASS_DRUID && tab == 1)
             engine->addStrategies("behind", "dps", NULL);
-        
+
         if (player->getClass() == CLASS_ROGUE)
             engine->addStrategies("behind", "stealth", NULL);
     }
@@ -472,7 +478,7 @@ void AiFactory::AddDefaultNonCombatStrategies(Player* player, PlayerbotAI* const
     }
 
     if ((facade->IsRealPlayer() || sRandomPlayerbotMgr.IsRandomBot(player)) && !player->InBattleGround())
-    {   
+    {
         if (!player->GetGroup() || player->GetGroup()->GetLeaderGuid() == player->GetObjectGuid())
         {
             // let 50% of random not grouped (or grp leader) bots help other players

--- a/playerbot/AiFactory.cpp
+++ b/playerbot/AiFactory.cpp
@@ -258,13 +258,13 @@ void AiFactory::AddDefaultCombatStrategies(Player* player, PlayerbotAI* const fa
                 engine->addStrategies("caster", "cure", "caster aoe", "threat", "flee", "dps assist", "ranged", NULL);
                 if (player->GetLevel() > 19)
                     engine->addStrategy("caster debuff");
-                if (player->GetGroup() == nullptr)
+                if (!player->GetGroup())
                     engine->addStrategy("cc");
             }
             else if (tab == 2)
             {
                 engine->addStrategies("heal", "cure", "flee", "dps assist", "ranged", NULL);
-                if (player->GetGroup() == nullptr)
+                if (!player->GetGroup())
                     engine->addStrategy("cc");
             }
             else

--- a/playerbot/PlayerbotAIConfig.cpp
+++ b/playerbot/PlayerbotAIConfig.cpp
@@ -106,6 +106,7 @@ bool PlayerbotAIConfig::Initialize()
     lowHealth = config.GetIntDefault("AiPlayerbot.LowHealth", 50);
     mediumHealth = config.GetIntDefault("AiPlayerbot.MediumHealth", 70);
     almostFullHealth = config.GetIntDefault("AiPlayerbot.AlmostFullHealth", 85);
+    lostAnyHealth = config.GetIntDefault("AiPlayerbot.LostAnyHealth", 98);
     lowMana = config.GetIntDefault("AiPlayerbot.LowMana", 15);
     mediumMana = config.GetIntDefault("AiPlayerbot.MediumMana", 40);
 
@@ -169,7 +170,7 @@ bool PlayerbotAIConfig::Initialize()
     sLog.outString("          Loading TalentSpecs          ");
     sLog.outString("---------------------------------------");
     sLog.outString();
-    
+
     for (uint32 cls = 1; cls < MAX_CLASSES; ++cls)
     {
         classSpecs[cls] = ClassSpecs(1 << (cls - 1));
@@ -244,7 +245,7 @@ bool PlayerbotAIConfig::Initialize()
     LoadListString<list<string>>(config.GetStringDefault("AiPlayerbot.AllowedLogFiles", ""), allowedLogFiles);
 
     worldBuffs.clear();
-    
+
     for (uint32 factionId = 0; factionId < 3; factionId++)
     {
         for (uint32 classId = 0; classId < MAX_CLASSES; classId++)
@@ -528,7 +529,7 @@ bool PlayerbotAIConfig::openLog(string fileName, char const* mode)
 {
     if (!hasLog(fileName))
         return false;
-     
+
     auto logFileIt = logFiles.find(fileName);
     if (logFileIt == logFiles.end())
     {
@@ -555,7 +556,7 @@ bool PlayerbotAIConfig::openLog(string fileName, char const* mode)
 
     logFileIt->second.first = file;
     logFileIt->second.second = fileOpen;
-    
+
     return true;
 }
 

--- a/playerbot/PlayerbotAIConfig.h
+++ b/playerbot/PlayerbotAIConfig.h
@@ -41,7 +41,7 @@ public:
     float sightDistance, spellDistance, reactDistance, grindDistance, lootDistance, shootDistance,
         fleeDistance, tooCloseDistance, meleeDistance, followDistance, whisperDistance, contactDistance,
         aoeRadius, rpgDistance, targetPosRecalcDistance, farDistance, healDistance, aggroDistance, stanceDistance, forceFollowDistance;
-    uint32 criticalHealth, lowHealth, mediumHealth, almostFullHealth;
+    uint32 criticalHealth, lowHealth, mediumHealth, almostFullHealth, lostAnyHealth;
     uint32 lowMana, mediumMana;
 
     uint32 openGoSpell;

--- a/playerbot/strategy/druid/CasterDruidStrategy.cpp
+++ b/playerbot/strategy/druid/CasterDruidStrategy.cpp
@@ -16,7 +16,6 @@ public:
         creators["entangling roots"] = &entangling_roots;
         creators["entangling roots on cc"] = &entangling_roots_on_cc;
         creators["wrath"] = &wrath;
-        creators["starfall"] = &starfall;
         creators["insect swarm"] = &insect_swarm;
         creators["moonfire"] = &moonfire;
         creators["starfire"] = &starfire;
@@ -57,13 +56,7 @@ private:
             /*A*/ NULL,
             /*C*/ NULL);
     }
-    static ActionNode* starfall(PlayerbotAI* ai)
-    {
-        return new ActionNode ("starfall",
-            /*P*/ NextAction::array(0, new NextAction("moonkin form"), NULL),
-            /*A*/ NextAction::array(0, new NextAction("hurricane"), NULL),
-            /*C*/ NULL);
-    }
+
     static ActionNode* insect_swarm(PlayerbotAI* ai)
     {
         return new ActionNode ("insect swarm",
@@ -154,7 +147,12 @@ void CasterDruidAoeStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
 {
 	triggers.push_back(new TriggerNode(
 		"high aoe",
-		NextAction::array(0, new NextAction("starfall", ACTION_HIGH + 1), NULL)));
+		NextAction::array(0, new NextAction("hurricane", ACTION_HIGH), NULL)));
+
+    // maybe allow the caster to only perform starfall on less thread, since starfall and hurrican generates a lot of thread!
+    triggers.push_back(new TriggerNode(
+        "high aoe",
+        NextAction::array(0, new NextAction("starfall", ACTION_HIGH + 1), NULL)));
 }
 
 void CasterDruidDebuffStrategy::InitTriggers(std::list<TriggerNode*> &triggers)

--- a/playerbot/strategy/druid/CasterDruidStrategy.cpp
+++ b/playerbot/strategy/druid/CasterDruidStrategy.cpp
@@ -116,13 +116,13 @@ void CasterDruidStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
         NextAction::array(0, new NextAction("rejuvenation on party", ACTION_LIGHT_HEAL + 1), NULL)));
 
 
-	triggers.push_back(new TriggerNode(
-		"insect swarm",
-		NextAction::array(0, new NextAction("insect swarm", ACTION_NORMAL + 5), NULL)));
+    triggers.push_back(new TriggerNode(
+        "insect swarm",
+        NextAction::array(0, new NextAction("insect swarm", ACTION_NORMAL + 5), NULL)));
 
-	triggers.push_back(new TriggerNode(
-		"moonfire",
-		NextAction::array(0, new NextAction("moonfire", ACTION_NORMAL + 4), NULL)));
+    triggers.push_back(new TriggerNode(
+        "moonfire",
+        NextAction::array(0, new NextAction("moonfire", ACTION_NORMAL + 4), NULL)));
 
     triggers.push_back(new TriggerNode(
         "eclipse (solar)",
@@ -136,18 +136,20 @@ void CasterDruidStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
         "moonfire",
         NextAction::array(0, new NextAction("moonfire", ACTION_NORMAL + 4), NULL)));
 
-
-
-	triggers.push_back(new TriggerNode(
+    triggers.push_back(new TriggerNode(
         "critical health",
-		NextAction::array(0, new NextAction("nature's grasp", ACTION_EMERGENCY), NULL)));
+        NextAction::array(0, new NextAction("nature's grasp", ACTION_EMERGENCY), NULL)));
+
+    triggers.push_back(new TriggerNode(
+        "enemy is close",
+        NextAction::array(0, new NextAction("typhoon", 30.0f), NULL)));
 }
 
 void CasterDruidAoeStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
 {
-	triggers.push_back(new TriggerNode(
-		"high aoe",
-		NextAction::array(0, new NextAction("hurricane", ACTION_HIGH), NULL)));
+    triggers.push_back(new TriggerNode(
+        "high aoe",
+        NextAction::array(0, new NextAction("hurricane", ACTION_HIGH), NULL)));
 
     // maybe allow the caster to only perform starfall on less thread, since starfall and hurrican generates a lot of thread!
     triggers.push_back(new TriggerNode(

--- a/playerbot/strategy/druid/DruidActions.h
+++ b/playerbot/strategy/druid/DruidActions.h
@@ -282,6 +282,8 @@ namespace ai
 		CastLifeBloomOnPartyAction(PlayerbotAI* ai) : HealPartyMemberAction(ai, "lifebloom") {}
 	};
 
+	BUFF_PARTY_ACTION(CastRejuvenationHotOnPartyAction, "rejuvenation");
+
 	HEAL_ACTION(CastNourishAction, "nourish");
 	HEAL_PARTY_ACTION(CastNourishOnPartyAction, "nourish");
 

--- a/playerbot/strategy/druid/DruidActions.h
+++ b/playerbot/strategy/druid/DruidActions.h
@@ -134,10 +134,6 @@ namespace ai
 	{
 	public:
 		CastStarfallAction(PlayerbotAI* ai) : CastBuffSpellAction(ai, "starfall") {}
-		virtual bool isUseful()
-		{
-			return sServerFacade.IsDistanceLessOrEqualThan(AI_VALUE2(float, "distance", GetTargetName()), 25.0f);
-		}
 	};
 
 	class CastHurricaneAction : public CastRangeSpellAction

--- a/playerbot/strategy/druid/DruidActions.h
+++ b/playerbot/strategy/druid/DruidActions.h
@@ -110,10 +110,14 @@ namespace ai
 		CastWrathAction(PlayerbotAI* ai) : CastRangeSpellAction(ai, "wrath") {}
 	};
 
-	class CastStarfallAction : public CastRangeSpellAction
+	class CastStarfallAction : public CastBuffSpellAction
 	{
 	public:
-		CastStarfallAction(PlayerbotAI* ai) : CastRangeSpellAction(ai, "starfall") {}
+		CastStarfallAction(PlayerbotAI* ai) : CastBuffSpellAction(ai, "starfall") {}
+		virtual bool isUseful()
+		{
+			return sServerFacade.IsDistanceLessOrEqualThan(AI_VALUE2(float, "distance", GetTargetName()), 25.0f);
+		}
 	};
 
 	class CastHurricaneAction : public CastRangeSpellAction
@@ -201,10 +205,10 @@ namespace ai
         virtual NextAction** getAlternatives();
     };
 
-    class CastBarskinAction : public CastBuffSpellAction
+    class CastBarkskinAction : public CastBuffSpellAction
     {
     public:
-        CastBarskinAction(PlayerbotAI* ai) : CastBuffSpellAction(ai, "barskin") {}
+        CastBarkskinAction(PlayerbotAI* ai) : CastBuffSpellAction(ai, "barkskin") {}
     };
 
     class CastInnervateAction : public CastRangeSpellAction

--- a/playerbot/strategy/druid/DruidActions.h
+++ b/playerbot/strategy/druid/DruidActions.h
@@ -7,6 +7,38 @@
 
 namespace ai
 {
+	class CastHealingWithHotSpellAction : public CastRangeSpellAction
+	{
+	public:
+		CastHealingWithHotSpellAction(PlayerbotAI* ai, string spell, uint8 estAmount = 15.0f) : CastRangeSpellAction(ai, spell)
+		{
+			this->estAmount = estAmount;
+			range = ai->GetRange("spell");
+		}
+		virtual string GetTargetName() { return "self target"; }
+		virtual ActionThreatType getThreatType() { return ACTION_THREAT_AOE; }
+
+		virtual bool isUseful()
+		{
+			// we ignore the give aura here, since it is still a valid healing effect - the hot is just sugar
+			return GetTarget() && (GetTarget() != nullptr) && (GetTarget() != NULL) && CastRangeSpellAction::isUseful();
+		}
+
+
+	protected:
+		uint8 estAmount;
+	};
+
+	class HealWithHotPartyMemberAction : public CastHealingWithHotSpellAction, public PartyMemberActionNameSupport
+	{
+	public:
+		HealWithHotPartyMemberAction(PlayerbotAI* ai, string spell, uint8 estAmount = 15.0f) :
+			CastHealingWithHotSpellAction(ai, spell, estAmount), PartyMemberActionNameSupport(spell) {}
+
+		virtual string GetTargetName() { return "party member to heal"; }
+		virtual string getName() { return PartyMemberActionNameSupport::getName(); }
+	};
+
 	class CastFaerieFireAction : public CastDebuffSpellAction
 	{
 	public:
@@ -24,9 +56,9 @@ namespace ai
 		CastRejuvenationAction(PlayerbotAI* ai) : CastHealingSpellAction(ai, "rejuvenation") {}
 	};
 
-	class CastRegrowthAction : public CastHealingSpellAction {
+	class CastRegrowthAction : public CastHealingWithHotSpellAction {
 	public:
-		CastRegrowthAction(PlayerbotAI* ai) : CastHealingSpellAction(ai, "regrowth") {}
+		CastRegrowthAction(PlayerbotAI* ai) : CastHealingWithHotSpellAction(ai, "regrowth") {}
 
 	};
 
@@ -41,10 +73,10 @@ namespace ai
         CastRejuvenationOnPartyAction(PlayerbotAI* ai) : HealPartyMemberAction(ai, "rejuvenation") {}
     };
 
-    class CastRegrowthOnPartyAction : public HealPartyMemberAction
+    class CastRegrowthOnPartyAction : public HealWithHotPartyMemberAction
     {
     public:
-        CastRegrowthOnPartyAction(PlayerbotAI* ai) : HealPartyMemberAction(ai, "regrowth") {}
+        CastRegrowthOnPartyAction(PlayerbotAI* ai) : HealWithHotPartyMemberAction(ai, "regrowth") {}
     };
 
     class CastHealingTouchOnPartyAction : public HealPartyMemberAction
@@ -58,9 +90,9 @@ namespace ai
 	public:
 		CastReviveAction(PlayerbotAI* ai) : ResurrectPartyMemberAction(ai, "revive") {}
 
-		virtual NextAction** getPrerequisites() {
+		/*virtual NextAction** getPrerequisites() {
 			return NextAction::merge( NextAction::array(0, new NextAction("caster form"), NULL), ResurrectPartyMemberAction::getPrerequisites());
-		}
+		}*/
 	};
 
 	class CastRebirthAction : public ResurrectPartyMemberAction
@@ -68,9 +100,9 @@ namespace ai
 	public:
 		CastRebirthAction(PlayerbotAI* ai) : ResurrectPartyMemberAction(ai, "rebirth") {}
 
-		virtual NextAction** getPrerequisites() {
+		/*virtual NextAction** getPrerequisites() {
 			return NextAction::merge( NextAction::array(0, new NextAction("caster form"), NULL), ResurrectPartyMemberAction::getPrerequisites());
-		}
+		}*/
 	};
 
 	class CastMarkOfTheWildAction : public CastBuffSpellAction {
@@ -250,25 +282,11 @@ namespace ai
 		CastLifeBloomOnPartyAction(PlayerbotAI* ai) : HealPartyMemberAction(ai, "lifebloom") {}
 	};
 
-	class CastNourishAction : public CastHealingSpellAction {
-	public:
-		CastNourishAction(PlayerbotAI* ai) : CastHealingSpellAction(ai, "nourish") {}
-	};
+	HEAL_ACTION(CastNourishAction, "nourish");
+	HEAL_PARTY_ACTION(CastNourishOnPartyAction, "nourish");
 
-	class CastNourishOnPartyAction : public HealPartyMemberAction {
-	public:
-		CastNourishOnPartyAction(PlayerbotAI* ai) : HealPartyMemberAction(ai, "nourish") {}
-	};
-
-	class CastWildGrowthAction : public CastHealingSpellAction {
-	public:
-		CastWildGrowthAction(PlayerbotAI* ai) : CastHealingSpellAction(ai, "wild growth") {}
-	};
-
-	class CastWildGrowthOnPartyAction : public HealPartyMemberAction {
-	public:
-		CastWildGrowthOnPartyAction(PlayerbotAI* ai) : HealPartyMemberAction(ai, "wild growth") {}
-	};
+	HEAL_ACTION(CastWildGrowthAction, "wild growth");
+	HEAL_PARTY_ACTION(CastWildGrowthOnPartyAction, "wild growth");
 
 	class CastForceOfNatureAction : public CastRangeSpellAction
 	{
@@ -276,15 +294,6 @@ namespace ai
 		CastForceOfNatureAction(PlayerbotAI* ai) : CastRangeSpellAction(ai, "force of nature") {}
 	};
 
-	class CastCycloneAction : public CastRangeSpellAction
-	{
-	public:
-		CastCycloneAction(PlayerbotAI* ai) : CastRangeSpellAction(ai, "cyclone") {}
-	};
-
-	class CastTyphoonAction : public CastRangeSpellAction
-	{
-	public:
-		CastTyphoonAction(PlayerbotAI* ai) : CastRangeSpellAction(ai, "typhoon") {}
-	};
+	CC_ACTION(CastCycloneAction, "cyclone");
+	SPELL_ACTION(CastTyphoonAction, "typhoon");
 }

--- a/playerbot/strategy/druid/DruidActions.h
+++ b/playerbot/strategy/druid/DruidActions.h
@@ -33,7 +33,6 @@ namespace ai
     class CastHealingTouchAction : public CastHealingSpellAction {
     public:
         CastHealingTouchAction(PlayerbotAI* ai) : CastHealingSpellAction(ai, "healing touch") {}
-
     };
 
     class CastRejuvenationOnPartyAction : public HealPartyMemberAction
@@ -230,4 +229,62 @@ namespace ai
     public:
         CastNaturesSwiftnessAction(PlayerbotAI* ai) : CastBuffSpellAction(ai, "nature's swiftness") {}
     };
+
+	class CastSwiftmendAction : public CastHealingSpellAction {
+	public:
+		CastSwiftmendAction(PlayerbotAI* ai) : CastHealingSpellAction(ai, "swiftmend") {}
+	};
+
+	class CastSwiftmendOnPartyAction : public HealPartyMemberAction {
+	public:
+		CastSwiftmendOnPartyAction(PlayerbotAI* ai) : HealPartyMemberAction(ai, "swiftmend") {}
+	};
+
+	class CastLifeBloomAction : public CastHealingSpellAction {
+	public:
+		CastLifeBloomAction(PlayerbotAI* ai) : CastHealingSpellAction(ai, "lifebloom") {}
+	};
+
+	class CastLifeBloomOnPartyAction : public HealPartyMemberAction {
+	public:
+		CastLifeBloomOnPartyAction(PlayerbotAI* ai) : HealPartyMemberAction(ai, "lifebloom") {}
+	};
+
+	class CastNourishAction : public CastHealingSpellAction {
+	public:
+		CastNourishAction(PlayerbotAI* ai) : CastHealingSpellAction(ai, "nourish") {}
+	};
+
+	class CastNourishOnPartyAction : public HealPartyMemberAction {
+	public:
+		CastNourishOnPartyAction(PlayerbotAI* ai) : HealPartyMemberAction(ai, "nourish") {}
+	};
+
+	class CastWildGrowthAction : public CastHealingSpellAction {
+	public:
+		CastWildGrowthAction(PlayerbotAI* ai) : CastHealingSpellAction(ai, "wild growth") {}
+	};
+
+	class CastWildGrowthOnPartyAction : public HealPartyMemberAction {
+	public:
+		CastWildGrowthOnPartyAction(PlayerbotAI* ai) : HealPartyMemberAction(ai, "wild growth") {}
+	};
+
+	class CastForceOfNatureAction : public CastRangeSpellAction
+	{
+	public:
+		CastForceOfNatureAction(PlayerbotAI* ai) : CastRangeSpellAction(ai, "force of nature") {}
+	};
+
+	class CastCycloneAction : public CastRangeSpellAction
+	{
+	public:
+		CastCycloneAction(PlayerbotAI* ai) : CastRangeSpellAction(ai, "cyclone") {}
+	};
+
+	class CastTyphoonAction : public CastRangeSpellAction
+	{
+	public:
+		CastTyphoonAction(PlayerbotAI* ai) : CastRangeSpellAction(ai, "typhoon") {}
+	};
 }

--- a/playerbot/strategy/druid/DruidActions.h
+++ b/playerbot/strategy/druid/DruidActions.h
@@ -249,6 +249,9 @@ namespace ai
     {
     public:
         CastNaturesSwiftnessAction(PlayerbotAI* ai) : CastBuffSpellAction(ai, "nature's swiftness") {}
+		virtual bool Execute(Event event) {
+			return CastBuffSpellAction::Execute(event);
+		}
     };
 
 	class CastSwiftmendAction : public CastHealingSpellAction {
@@ -284,36 +287,6 @@ namespace ai
 	public:
 		CastNourishOnPartyAction(PlayerbotAI* ai) : HealPartyMemberAction(ai, "nourish") {}
 		virtual bool isUseful() { return HealPartyMemberAction::isUseful() && ai->HasAnyAuraOf(GetTarget(), "rejuvenation", "regrowth", "lifebloom", "wild growth", NULL); }
-	};
-
-	class CastInstantHealingTouchAction : public CastHealingSpellAction {
-	public:
-		CastInstantHealingTouchAction(PlayerbotAI* ai) : CastHealingSpellAction(ai, "healing touch") {}
-		virtual bool isUseful() { return CastHealingSpellAction::isUseful() && ai->CanCastSpellInstant(spell, GetTarget());
-		}
-	};
-	class CastInstantHealingTouchOnPartyAction : public HealPartyMemberAction {
-	public:
-		CastInstantHealingTouchOnPartyAction(PlayerbotAI* ai) : HealPartyMemberAction(ai, "healing touch") {}
-		virtual bool isUseful() { return HealPartyMemberAction::isUseful() && ai->CanCastSpellInstant(spell, GetTarget()); }
-	};
-
-	class CastInstantLifeBloomAction : public CastRangeSpellAction {
-	public:
-		CastInstantLifeBloomAction(PlayerbotAI* ai) : CastRangeSpellAction(ai, "lifebloom") {}
-		virtual bool isUseful() {
-			return CastRangeSpellAction::isUseful() && ai->CanCastSpellInstant(spell, GetTarget());
-		}
-	};
-	class CastInstantLifeBloomOnPartyAction : public CastRangeSpellAction, public PartyMemberActionNameSupport {
-	public:
-		CastInstantLifeBloomOnPartyAction(PlayerbotAI* ai)
-			: CastRangeSpellAction(ai, "lifebloom"), PartyMemberActionNameSupport("lifebloom") {}
-		virtual string GetTargetName() { return "party member to heal"; }
-		virtual string getName() { return PartyMemberActionNameSupport::getName(); }
-		virtual bool isUseful() {
-			return CastRangeSpellAction::isUseful() && ai->CanCastSpellInstant(spell, GetTarget());
-		}
 	};
 
 	AOE_HEAL_ACTION(CastWildGrowthAction, "wild growth");

--- a/playerbot/strategy/druid/DruidActions.h
+++ b/playerbot/strategy/druid/DruidActions.h
@@ -305,6 +305,16 @@ namespace ai
 			return CastRangeSpellAction::isUseful() && ai->CanCastSpellInstant(spell, GetTarget());
 		}
 	};
+	class CastInstantLifeBloomOnPartyAction : public CastRangeSpellAction, public PartyMemberActionNameSupport {
+	public:
+		CastInstantLifeBloomOnPartyAction(PlayerbotAI* ai)
+			: CastRangeSpellAction(ai, "lifebloom"), PartyMemberActionNameSupport("lifebloom") {}
+		virtual string GetTargetName() { return "party member to heal"; }
+		virtual string getName() { return PartyMemberActionNameSupport::getName(); }
+		virtual bool isUseful() {
+			return CastRangeSpellAction::isUseful() && ai->CanCastSpellInstant(spell, GetTarget());
+		}
+	};
 
 	AOE_HEAL_ACTION(CastWildGrowthAction, "wild growth");
 

--- a/playerbot/strategy/druid/DruidAiObjectContext.cpp
+++ b/playerbot/strategy/druid/DruidAiObjectContext.cpp
@@ -222,6 +222,7 @@ namespace ai
                 creators["lifebloom"] = &AiObjectContextInternal::lifebloom;
                 creators["lifebloom on party"] = &AiObjectContextInternal::lifebloom_on_party;
                 creators["instant lifebloom"] = &AiObjectContextInternal::instant_lifebloom;
+                creators["instant lifebloom on party"] = &AiObjectContextInternal::instant_lifebloom_on_party;
                 creators["rebirth"] = &AiObjectContextInternal::rebirth;
                 creators["revive"] = &AiObjectContextInternal::revive;
                 creators["barkskin"] = &AiObjectContextInternal::barkskin;
@@ -307,6 +308,7 @@ namespace ai
             static Action* lifebloom(PlayerbotAI* ai) { return new CastLifeBloomAction(ai); }
             static Action* lifebloom_on_party(PlayerbotAI* ai) { return new CastLifeBloomOnPartyAction(ai); }
             static Action* instant_lifebloom(PlayerbotAI* ai) { return new CastInstantLifeBloomAction(ai); }
+            static Action* instant_lifebloom_on_party(PlayerbotAI* ai) { return new CastInstantLifeBloomOnPartyAction(ai); }
             static Action* nourish(PlayerbotAI* ai) { return new CastNourishAction(ai); }
             static Action* nourish_on_party(PlayerbotAI* ai) { return new CastNourishOnPartyAction(ai); }
             static Action* wild_growth(PlayerbotAI* ai) { return new CastWildGrowthAction(ai); }

--- a/playerbot/strategy/druid/DruidAiObjectContext.cpp
+++ b/playerbot/strategy/druid/DruidAiObjectContext.cpp
@@ -109,6 +109,11 @@ namespace ai
                 creators["force of nature"] = &TriggerFactoryInternal::force_of_nature;
                 creators["rejuvenation hot on party"] = &TriggerFactoryInternal::rejuvenation_hot_on_party;
                 creators["rejuvenation hot on tank"] = &TriggerFactoryInternal::rejuvenation_hot_on_tank;
+                creators["clearcasting"] = &TriggerFactoryInternal::clearcasting;
+                creators["low or critical health and clearcasting"] = &TriggerFactoryInternal::low_or_critical_health_and_clearcasting;
+                creators["party member low or critical health and clearcasting"] = &TriggerFactoryInternal::party_member_low_or_critical_health_and_clearcasting;
+                creators["low or critical health and natures swiftness"] = &TriggerFactoryInternal::low_or_critical_health_and_natures_swiftness;
+                creators["party member low or critical health and natures swiftness"] = &TriggerFactoryInternal::party_member_low_or_critical_health_and_natures_swiftness;
             }
 
         private:
@@ -140,6 +145,11 @@ namespace ai
             static Trigger* force_of_nature(PlayerbotAI* ai) { return new ForceOfNatureTrigger(ai); }
             static Trigger* rejuvenation_hot_on_party(PlayerbotAI* ai) { return new RejuvenationHotOnPartyTrigger(ai); }
             static Trigger* rejuvenation_hot_on_tank(PlayerbotAI* ai) { return new RejuvenationHotOnTankTrigger(ai); }
+            static Trigger* clearcasting(PlayerbotAI* ai) { return new ClearCastingTrigger(ai); }
+            static Trigger* low_or_critical_health_and_clearcasting(PlayerbotAI* ai) { return new LowOrCriticalHealthAndClearCastingTrigger(ai); }
+            static Trigger* party_member_low_or_critical_health_and_clearcasting(PlayerbotAI* ai) { return new PartyMemberLowOrCriticalHealthAndClearCastingTrigger(ai); }
+            static Trigger* low_or_critical_health_and_natures_swiftness(PlayerbotAI* ai) { return new LowOrCriticalHealthAndAndNaturesSwiftnessTrigger(ai); }
+            static Trigger* party_member_low_or_critical_health_and_natures_swiftness(PlayerbotAI* ai) { return new PartyMemberLowOrCriticalHealthAndNaturesSwiftnessTrigger(ai); }
         };
     };
 };
@@ -212,8 +222,6 @@ namespace ai
                 creators["rejuvenation hot on party"] = &AiObjectContextInternal::rejuvenation_hot_on_party;
                 creators["healing touch"] = &AiObjectContextInternal::healing_touch;
                 creators["healing touch on party"] = &AiObjectContextInternal::healing_touch_on_party;
-                creators["instant healing touch"] = &AiObjectContextInternal::instant_healing_touch;
-                creators["instant healing touch on party"] = &AiObjectContextInternal::instant_healing_touch_on_party;
                 creators["swiftmend"] = &AiObjectContextInternal::swiftmend;
                 creators["swiftmend on party"] = &AiObjectContextInternal::swiftmend_on_party;
                 creators["nourish"] = &AiObjectContextInternal::nourish;
@@ -221,8 +229,6 @@ namespace ai
                 creators["wild growth"] = &AiObjectContextInternal::wild_growth;
                 creators["lifebloom"] = &AiObjectContextInternal::lifebloom;
                 creators["lifebloom on party"] = &AiObjectContextInternal::lifebloom_on_party;
-                creators["instant lifebloom"] = &AiObjectContextInternal::instant_lifebloom;
-                creators["instant lifebloom on party"] = &AiObjectContextInternal::instant_lifebloom_on_party;
                 creators["rebirth"] = &AiObjectContextInternal::rebirth;
                 creators["revive"] = &AiObjectContextInternal::revive;
                 creators["barkskin"] = &AiObjectContextInternal::barkskin;
@@ -302,13 +308,10 @@ namespace ai
             static Action* regrowth(PlayerbotAI* ai) { return new CastRegrowthAction(ai); }
             static Action* rejuvenation(PlayerbotAI* ai) { return new CastRejuvenationAction(ai); }
             static Action* healing_touch(PlayerbotAI* ai) { return new CastHealingTouchAction(ai); }
-            static Action* instant_healing_touch(PlayerbotAI* ai) { return new CastInstantHealingTouchAction(ai); }
             static Action* swiftmend(PlayerbotAI* ai) { return new CastSwiftmendAction(ai); }
             static Action* swiftmend_on_party(PlayerbotAI* ai) { return new CastSwiftmendOnPartyAction(ai); }
             static Action* lifebloom(PlayerbotAI* ai) { return new CastLifeBloomAction(ai); }
             static Action* lifebloom_on_party(PlayerbotAI* ai) { return new CastLifeBloomOnPartyAction(ai); }
-            static Action* instant_lifebloom(PlayerbotAI* ai) { return new CastInstantLifeBloomAction(ai); }
-            static Action* instant_lifebloom_on_party(PlayerbotAI* ai) { return new CastInstantLifeBloomOnPartyAction(ai); }
             static Action* nourish(PlayerbotAI* ai) { return new CastNourishAction(ai); }
             static Action* nourish_on_party(PlayerbotAI* ai) { return new CastNourishOnPartyAction(ai); }
             static Action* wild_growth(PlayerbotAI* ai) { return new CastWildGrowthAction(ai); }
@@ -318,7 +321,6 @@ namespace ai
             static Action* rejuvenation_on_party(PlayerbotAI* ai) { return new CastRejuvenationOnPartyAction(ai); }
             static Action* rejuvenation_hot_on_party(PlayerbotAI* ai) { return new CastRejuvenationHotOnPartyAction(ai); }
             static Action* healing_touch_on_party(PlayerbotAI* ai) { return new CastHealingTouchOnPartyAction(ai); }
-            static Action* instant_healing_touch_on_party(PlayerbotAI* ai) { return new CastInstantHealingTouchOnPartyAction(ai); }
             static Action* rebirth(PlayerbotAI* ai) { return new CastRebirthAction(ai); }
             static Action* revive(PlayerbotAI* ai) { return new CastReviveAction(ai); }
             static Action* barkskin(PlayerbotAI* ai) { return new CastBarkskinAction(ai); }

--- a/playerbot/strategy/druid/DruidAiObjectContext.cpp
+++ b/playerbot/strategy/druid/DruidAiObjectContext.cpp
@@ -205,7 +205,7 @@ namespace ai
                 creators["healing touch on party"] = &AiObjectContextInternal::healing_touch_on_party;
                 creators["rebirth"] = &AiObjectContextInternal::rebirth;
                 creators["revive"] = &AiObjectContextInternal::revive;
-                creators["barskin"] = &AiObjectContextInternal::barskin;
+                creators["barkskin"] = &AiObjectContextInternal::barkskin;
                 creators["lacerate"] = &AiObjectContextInternal::lacerate;
                 creators["hurricane"] = &AiObjectContextInternal::hurricane;
                 creators["innervate"] = &AiObjectContextInternal::innervate;
@@ -284,7 +284,7 @@ namespace ai
             static Action* healing_touch_on_party(PlayerbotAI* ai) { return new CastHealingTouchOnPartyAction(ai); }
             static Action* rebirth(PlayerbotAI* ai) { return new CastRebirthAction(ai); }
             static Action* revive(PlayerbotAI* ai) { return new CastReviveAction(ai); }
-            static Action* barskin(PlayerbotAI* ai) { return new CastBarskinAction(ai); }
+            static Action* barkskin(PlayerbotAI* ai) { return new CastBarkskinAction(ai); }
             static Action* lacerate(PlayerbotAI* ai) { return new CastLacerateAction(ai); }
             static Action* hurricane(PlayerbotAI* ai) { return new CastHurricaneAction(ai); }
             static Action* innervate(PlayerbotAI* ai) { return new CastInnervateAction(ai); }

--- a/playerbot/strategy/druid/DruidAiObjectContext.cpp
+++ b/playerbot/strategy/druid/DruidAiObjectContext.cpp
@@ -198,11 +198,19 @@ namespace ai
                 creators["mark of the wild"] = &AiObjectContextInternal::mark_of_the_wild;
                 creators["mark of the wild on party"] = &AiObjectContextInternal::mark_of_the_wild_on_party;
                 creators["regrowth"] = &AiObjectContextInternal::regrowth;
-                creators["rejuvenation"] = &AiObjectContextInternal::rejuvenation;
-                creators["healing touch"] = &AiObjectContextInternal::healing_touch;
                 creators["regrowth on party"] = &AiObjectContextInternal::regrowth_on_party;
+                creators["rejuvenation"] = &AiObjectContextInternal::rejuvenation;
                 creators["rejuvenation on party"] = &AiObjectContextInternal::rejuvenation_on_party;
+                creators["healing touch"] = &AiObjectContextInternal::healing_touch;
                 creators["healing touch on party"] = &AiObjectContextInternal::healing_touch_on_party;
+                creators["swiftmend"] = &AiObjectContextInternal::swiftmend;
+                creators["swiftmend on party"] = &AiObjectContextInternal::swiftmend_on_party;
+                creators["nourish"] = &AiObjectContextInternal::nourish;
+                creators["nourish on party"] = &AiObjectContextInternal::nourish_on_party;
+                creators["wild growth"] = &AiObjectContextInternal::wild_growth;
+                creators["wild growth on party"] = &AiObjectContextInternal::wild_growth_on_party;
+                creators["lifebloom"] = &AiObjectContextInternal::lifebloom;
+                creators["lifebloom on party"] = &AiObjectContextInternal::lifebloom_on_party;
                 creators["rebirth"] = &AiObjectContextInternal::rebirth;
                 creators["revive"] = &AiObjectContextInternal::revive;
                 creators["barkskin"] = &AiObjectContextInternal::barkskin;
@@ -213,6 +221,9 @@ namespace ai
                 creators["bash on enemy healer"] = &AiObjectContextInternal::bash_on_enemy_healer;
                 creators["omen of clarity"] = &AiObjectContextInternal::omen_of_clarity;
                 creators["nature's swiftness"] = &AiObjectContextInternal::natures_swiftness;
+                creators["typhoon"] = &AiObjectContextInternal::typhoon;
+                creators["force of nature"] = &AiObjectContextInternal::force_of_nature;
+                creators["cyclone"] = &AiObjectContextInternal::cyclone;
                 creators["prowl"] = &AiObjectContextInternal::prowl;
                 creators["dash"] = &AiObjectContextInternal::dash;
                 creators["shred"] = &AiObjectContextInternal::shred;
@@ -279,6 +290,14 @@ namespace ai
             static Action* regrowth(PlayerbotAI* ai) { return new CastRegrowthAction(ai); }
             static Action* rejuvenation(PlayerbotAI* ai) { return new CastRejuvenationAction(ai); }
             static Action* healing_touch(PlayerbotAI* ai) { return new CastHealingTouchAction(ai); }
+            static Action* swiftmend(PlayerbotAI* ai) { return new CastSwiftmendAction(ai); }
+            static Action* swiftmend_on_party(PlayerbotAI* ai) { return new CastSwiftmendOnPartyAction(ai); }
+            static Action* lifebloom(PlayerbotAI* ai) { return new CastLifeBloomAction(ai); }
+            static Action* lifebloom_on_party(PlayerbotAI* ai) { return new CastLifeBloomOnPartyAction(ai); }
+            static Action* nourish(PlayerbotAI* ai) { return new CastNourishAction(ai); }
+            static Action* nourish_on_party(PlayerbotAI* ai) { return new CastNourishOnPartyAction(ai); }
+            static Action* wild_growth(PlayerbotAI* ai) { return new CastWildGrowthAction(ai); }
+            static Action* wild_growth_on_party(PlayerbotAI* ai) { return new CastWildGrowthOnPartyAction(ai); }
             static Action* regrowth_on_party(PlayerbotAI* ai) { return new CastRegrowthOnPartyAction(ai); }
             static Action* rejuvenation_on_party(PlayerbotAI* ai) { return new CastRejuvenationOnPartyAction(ai); }
             static Action* healing_touch_on_party(PlayerbotAI* ai) { return new CastHealingTouchOnPartyAction(ai); }
@@ -289,6 +308,9 @@ namespace ai
             static Action* hurricane(PlayerbotAI* ai) { return new CastHurricaneAction(ai); }
             static Action* innervate(PlayerbotAI* ai) { return new CastInnervateAction(ai); }
             static Action* bash_on_enemy_healer(PlayerbotAI* ai) { return new CastBashOnEnemyHealerAction(ai); }
+            static Action* typhoon(PlayerbotAI* ai) { return new CastTyphoonAction(ai); }
+            static Action* force_of_nature(PlayerbotAI* ai) { return new CastForceOfNatureAction(ai); }
+            static Action* cyclone(PlayerbotAI* ai) { return new CastCycloneAction(ai); }
         };
     };
 };

--- a/playerbot/strategy/druid/DruidAiObjectContext.cpp
+++ b/playerbot/strategy/druid/DruidAiObjectContext.cpp
@@ -107,10 +107,6 @@ namespace ai
                 creators["bash on enemy healer"] = &TriggerFactoryInternal::bash_on_enemy_healer;
                 creators["nature's swiftness"] = &TriggerFactoryInternal::natures_swiftness;
                 creators["force of nature"] = &TriggerFactoryInternal::force_of_nature;
-                creators["nourish"] = &TriggerFactoryInternal::nourish;
-                creators["nourish on party"] = &TriggerFactoryInternal::nourish_on_party;
-                creators["swiftmend"] = &TriggerFactoryInternal::swiftmend;
-                creators["swiftmend on party"] = &TriggerFactoryInternal::swiftmend_on_party;
                 creators["rejuvenation hot on party"] = &TriggerFactoryInternal::rejuvenation_hot_on_party;
                 creators["rejuvenation hot on tank"] = &TriggerFactoryInternal::rejuvenation_hot_on_tank;
             }
@@ -142,10 +138,6 @@ namespace ai
             static Trigger* bash_on_enemy_healer(PlayerbotAI* ai) { return new BashInterruptEnemyHealerSpellTrigger(ai); }
             static Trigger* omen_of_clarity(PlayerbotAI* ai) { return new OmenOfClarityTrigger(ai); }
             static Trigger* force_of_nature(PlayerbotAI* ai) { return new ForceOfNatureTrigger(ai); }
-            static Trigger* nourish(PlayerbotAI* ai) { return new NourishAndMediumHealthTrigger(ai); }
-            static Trigger* nourish_on_party(PlayerbotAI* ai) { return new NourishOnPartyAndMediumHealthTrigger(ai); }
-            static Trigger* swiftmend(PlayerbotAI* ai) { return new SwiftmendAndLowHealthTrigger(ai); }
-            static Trigger* swiftmend_on_party(PlayerbotAI* ai) { return new SwiftmendOnPartyAndLowHealthTrigger(ai); }
             static Trigger* rejuvenation_hot_on_party(PlayerbotAI* ai) { return new RejuvenationHotOnPartyTrigger(ai); }
             static Trigger* rejuvenation_hot_on_tank(PlayerbotAI* ai) { return new RejuvenationHotOnTankTrigger(ai); }
         };
@@ -213,19 +205,23 @@ namespace ai
                 creators["mark of the wild on party"] = &AiObjectContextInternal::mark_of_the_wild_on_party;
                 creators["regrowth"] = &AiObjectContextInternal::regrowth;
                 creators["regrowth on party"] = &AiObjectContextInternal::regrowth_on_party;
+                creators["refresh regrowth"] = &AiObjectContextInternal::refresh_regrowth;
+                creators["refresh regrowth on party"] = &AiObjectContextInternal::refresh_regrowth_on_party;
                 creators["rejuvenation"] = &AiObjectContextInternal::rejuvenation;
                 creators["rejuvenation on party"] = &AiObjectContextInternal::rejuvenation_on_party;
                 creators["rejuvenation hot on party"] = &AiObjectContextInternal::rejuvenation_hot_on_party;
                 creators["healing touch"] = &AiObjectContextInternal::healing_touch;
                 creators["healing touch on party"] = &AiObjectContextInternal::healing_touch_on_party;
+                creators["instant healing touch"] = &AiObjectContextInternal::instant_healing_touch;
+                creators["instant healing touch on party"] = &AiObjectContextInternal::instant_healing_touch_on_party;
                 creators["swiftmend"] = &AiObjectContextInternal::swiftmend;
                 creators["swiftmend on party"] = &AiObjectContextInternal::swiftmend_on_party;
                 creators["nourish"] = &AiObjectContextInternal::nourish;
                 creators["nourish on party"] = &AiObjectContextInternal::nourish_on_party;
                 creators["wild growth"] = &AiObjectContextInternal::wild_growth;
-                creators["wild growth on party"] = &AiObjectContextInternal::wild_growth_on_party;
                 creators["lifebloom"] = &AiObjectContextInternal::lifebloom;
                 creators["lifebloom on party"] = &AiObjectContextInternal::lifebloom_on_party;
+                creators["instant lifebloom"] = &AiObjectContextInternal::instant_lifebloom;
                 creators["rebirth"] = &AiObjectContextInternal::rebirth;
                 creators["revive"] = &AiObjectContextInternal::revive;
                 creators["barkskin"] = &AiObjectContextInternal::barkskin;
@@ -305,18 +301,22 @@ namespace ai
             static Action* regrowth(PlayerbotAI* ai) { return new CastRegrowthAction(ai); }
             static Action* rejuvenation(PlayerbotAI* ai) { return new CastRejuvenationAction(ai); }
             static Action* healing_touch(PlayerbotAI* ai) { return new CastHealingTouchAction(ai); }
+            static Action* instant_healing_touch(PlayerbotAI* ai) { return new CastInstantHealingTouchAction(ai); }
             static Action* swiftmend(PlayerbotAI* ai) { return new CastSwiftmendAction(ai); }
             static Action* swiftmend_on_party(PlayerbotAI* ai) { return new CastSwiftmendOnPartyAction(ai); }
             static Action* lifebloom(PlayerbotAI* ai) { return new CastLifeBloomAction(ai); }
             static Action* lifebloom_on_party(PlayerbotAI* ai) { return new CastLifeBloomOnPartyAction(ai); }
+            static Action* instant_lifebloom(PlayerbotAI* ai) { return new CastInstantLifeBloomAction(ai); }
             static Action* nourish(PlayerbotAI* ai) { return new CastNourishAction(ai); }
             static Action* nourish_on_party(PlayerbotAI* ai) { return new CastNourishOnPartyAction(ai); }
             static Action* wild_growth(PlayerbotAI* ai) { return new CastWildGrowthAction(ai); }
-            static Action* wild_growth_on_party(PlayerbotAI* ai) { return new CastWildGrowthOnPartyAction(ai); }
             static Action* regrowth_on_party(PlayerbotAI* ai) { return new CastRegrowthOnPartyAction(ai); }
+            static Action* refresh_regrowth(PlayerbotAI* ai) { return new RefreshRegrowthAction(ai); }
+            static Action* refresh_regrowth_on_party(PlayerbotAI* ai) { return new RefreshRegrowthOnPartyAction(ai); }
             static Action* rejuvenation_on_party(PlayerbotAI* ai) { return new CastRejuvenationOnPartyAction(ai); }
             static Action* rejuvenation_hot_on_party(PlayerbotAI* ai) { return new CastRejuvenationHotOnPartyAction(ai); }
             static Action* healing_touch_on_party(PlayerbotAI* ai) { return new CastHealingTouchOnPartyAction(ai); }
+            static Action* instant_healing_touch_on_party(PlayerbotAI* ai) { return new CastInstantHealingTouchOnPartyAction(ai); }
             static Action* rebirth(PlayerbotAI* ai) { return new CastRebirthAction(ai); }
             static Action* revive(PlayerbotAI* ai) { return new CastReviveAction(ai); }
             static Action* barkskin(PlayerbotAI* ai) { return new CastBarkskinAction(ai); }

--- a/playerbot/strategy/druid/DruidAiObjectContext.cpp
+++ b/playerbot/strategy/druid/DruidAiObjectContext.cpp
@@ -106,6 +106,11 @@ namespace ai
                 creators["eclipse (lunar)"] = &TriggerFactoryInternal::eclipse_lunar;
                 creators["bash on enemy healer"] = &TriggerFactoryInternal::bash_on_enemy_healer;
                 creators["nature's swiftness"] = &TriggerFactoryInternal::natures_swiftness;
+                creators["force of nature"] = &TriggerFactoryInternal::force_of_nature;
+                creators["nourish"] = &TriggerFactoryInternal::nourish;
+                creators["nourish on party"] = &TriggerFactoryInternal::nourish_on_party;
+                creators["swiftmend"] = &TriggerFactoryInternal::swiftmend;
+                creators["swiftmend on party"] = &TriggerFactoryInternal::swiftmend_on_party;
             }
 
         private:
@@ -134,6 +139,11 @@ namespace ai
             static Trigger* tree_form(PlayerbotAI* ai) { return new TreeFormTrigger(ai); }
             static Trigger* bash_on_enemy_healer(PlayerbotAI* ai) { return new BashInterruptEnemyHealerSpellTrigger(ai); }
             static Trigger* omen_of_clarity(PlayerbotAI* ai) { return new OmenOfClarityTrigger(ai); }
+            static Trigger* force_of_nature(PlayerbotAI* ai) { return new ForceOfNatureTrigger(ai); }
+            static Trigger* nourish(PlayerbotAI* ai) { return new NourishAndMediumHealthTrigger(ai); }
+            static Trigger* nourish_on_party(PlayerbotAI* ai) { return new NourishOnPartyAndMediumHealthTrigger(ai); }
+            static Trigger* swiftmend(PlayerbotAI* ai) { return new SwiftmendAndLowHealthTrigger(ai); }
+            static Trigger* swiftmend_on_party(PlayerbotAI* ai) { return new SwiftmendOnPartyAndLowHealthTrigger(ai); }
         };
     };
 };

--- a/playerbot/strategy/druid/DruidAiObjectContext.cpp
+++ b/playerbot/strategy/druid/DruidAiObjectContext.cpp
@@ -111,6 +111,8 @@ namespace ai
                 creators["nourish on party"] = &TriggerFactoryInternal::nourish_on_party;
                 creators["swiftmend"] = &TriggerFactoryInternal::swiftmend;
                 creators["swiftmend on party"] = &TriggerFactoryInternal::swiftmend_on_party;
+                creators["rejuvenation hot on party"] = &TriggerFactoryInternal::rejuvenation_hot_on_party;
+                creators["rejuvenation hot on tank"] = &TriggerFactoryInternal::rejuvenation_hot_on_tank;
             }
 
         private:
@@ -144,6 +146,8 @@ namespace ai
             static Trigger* nourish_on_party(PlayerbotAI* ai) { return new NourishOnPartyAndMediumHealthTrigger(ai); }
             static Trigger* swiftmend(PlayerbotAI* ai) { return new SwiftmendAndLowHealthTrigger(ai); }
             static Trigger* swiftmend_on_party(PlayerbotAI* ai) { return new SwiftmendOnPartyAndLowHealthTrigger(ai); }
+            static Trigger* rejuvenation_hot_on_party(PlayerbotAI* ai) { return new RejuvenationHotOnPartyTrigger(ai); }
+            static Trigger* rejuvenation_hot_on_tank(PlayerbotAI* ai) { return new RejuvenationHotOnTankTrigger(ai); }
         };
     };
 };
@@ -211,6 +215,7 @@ namespace ai
                 creators["regrowth on party"] = &AiObjectContextInternal::regrowth_on_party;
                 creators["rejuvenation"] = &AiObjectContextInternal::rejuvenation;
                 creators["rejuvenation on party"] = &AiObjectContextInternal::rejuvenation_on_party;
+                creators["rejuvenation hot on party"] = &AiObjectContextInternal::rejuvenation_hot_on_party;
                 creators["healing touch"] = &AiObjectContextInternal::healing_touch;
                 creators["healing touch on party"] = &AiObjectContextInternal::healing_touch_on_party;
                 creators["swiftmend"] = &AiObjectContextInternal::swiftmend;
@@ -310,6 +315,7 @@ namespace ai
             static Action* wild_growth_on_party(PlayerbotAI* ai) { return new CastWildGrowthOnPartyAction(ai); }
             static Action* regrowth_on_party(PlayerbotAI* ai) { return new CastRegrowthOnPartyAction(ai); }
             static Action* rejuvenation_on_party(PlayerbotAI* ai) { return new CastRejuvenationOnPartyAction(ai); }
+            static Action* rejuvenation_hot_on_party(PlayerbotAI* ai) { return new CastRejuvenationHotOnPartyAction(ai); }
             static Action* healing_touch_on_party(PlayerbotAI* ai) { return new CastHealingTouchOnPartyAction(ai); }
             static Action* rebirth(PlayerbotAI* ai) { return new CastRebirthAction(ai); }
             static Action* revive(PlayerbotAI* ai) { return new CastReviveAction(ai); }

--- a/playerbot/strategy/druid/DruidTriggers.h
+++ b/playerbot/strategy/druid/DruidTriggers.h
@@ -187,40 +187,6 @@ namespace ai {
         virtual bool IsActive() { return BuffOnPartyTrigger::IsActive() && ai->HasAnyAuraOf(GetTarget(), "rejuvenation", "regrowth", "lifebloom", "wild growth", NULL); }
     };
 
-    class NourishAndMediumHealthTrigger : public AndTrigger {
-    public:
-        NourishAndMediumHealthTrigger(PlayerbotAI* ai) : AndTrigger(ai, new NourishTrigger(ai), new MediumHealthTrigger(ai)) {}
-    };
-
-    class NourishOnPartyAndMediumHealthTrigger : public AndTrigger {
-    public:
-        NourishOnPartyAndMediumHealthTrigger(PlayerbotAI* ai) : AndTrigger(ai, new NourishOnPartyTrigger(ai), new PartyMemberMediumHealthTrigger(ai)) {}
-    };
-
-    class SwiftmendTrigger : public BuffTrigger {
-    public:
-        SwiftmendTrigger(PlayerbotAI* ai) : BuffTrigger(ai, "swiftmend") {}
-
-        virtual bool IsActive() { return ai->HasAnyAuraOf(bot, "rejuvenation", "regrowth", NULL); }
-    };
-
-    class SwiftmendOnPartyTrigger : public BuffOnPartyTrigger {
-    public:
-        SwiftmendOnPartyTrigger(PlayerbotAI* ai) : BuffOnPartyTrigger(ai, "switfmend") {}
-
-        virtual bool IsActive() { return ai->HasAnyAuraOf(GetTarget(), "rejuvenation", "regrowth", NULL); }
-    };
-
-    class SwiftmendAndLowHealthTrigger : public AndTrigger {
-    public:
-        SwiftmendAndLowHealthTrigger(PlayerbotAI* ai) : AndTrigger(ai, new SwiftmendTrigger(ai), new LowHealthTrigger(ai)) {}
-    };
-
-    class SwiftmendOnPartyAndLowHealthTrigger : public AndTrigger {
-    public:
-        SwiftmendOnPartyAndLowHealthTrigger(PlayerbotAI* ai) : AndTrigger(ai, new SwiftmendOnPartyTrigger(ai), new PartyMemberLowHealthTrigger(ai)) {}
-    };
-
     BUFF_PARTY_TRIGGER(RejuvenationHotOnPartyTrigger, "rejuvenation");
 
     class RejuvenationHotOnTankTrigger : public BuffOnTankTrigger {

--- a/playerbot/strategy/druid/DruidTriggers.h
+++ b/playerbot/strategy/druid/DruidTriggers.h
@@ -187,10 +187,50 @@ namespace ai {
         virtual bool IsActive() { return BuffOnPartyTrigger::IsActive() && ai->HasAnyAuraOf(GetTarget(), "rejuvenation", "regrowth", "lifebloom", "wild growth", NULL); }
     };
 
-    BUFF_PARTY_TRIGGER(RejuvenationHotOnPartyTrigger, "rejuvenation");
+    class RejuvenationHotOnPartyTrigger : public BuffOnPartyTrigger {
+    public:
+        RejuvenationHotOnPartyTrigger(PlayerbotAI* ai) : BuffOnPartyTrigger(ai, "rejuvenation") {}
+    };
 
     class RejuvenationHotOnTankTrigger : public BuffOnTankTrigger {
     public:
         RejuvenationHotOnTankTrigger(PlayerbotAI* ai) : BuffOnTankTrigger(ai, "rejuvenation") {}
+    };
+
+    class ClearCastingTrigger : public HasAuraTrigger {
+    public:
+        ClearCastingTrigger(PlayerbotAI* ai) : HasAuraTrigger(ai, "Clearcasting") {}
+    };
+
+    class LowOrCriticalHealthAndClearCastingTrigger : public AndTrigger {
+    public:
+        LowOrCriticalHealthAndClearCastingTrigger(PlayerbotAI* ai)
+            : AndTrigger(ai, new ClearCastingTrigger(ai), new LowOrCriticalHealthTrigger(ai)) {}
+        virtual bool IsActive() {
+            auto result = AndTrigger::IsActive();
+            return result;
+        }
+    };
+
+    class PartyMemberLowOrCriticalHealthAndClearCastingTrigger : public AndTrigger {
+    public:
+        PartyMemberLowOrCriticalHealthAndClearCastingTrigger(PlayerbotAI* ai)
+            : AndTrigger(ai, new ClearCastingTrigger(ai), new PartyMemberLowOrCriticalHealthTrigger(ai)) {}
+        virtual bool IsActive() {
+            auto result = AndTrigger::IsActive();
+            return result;
+        }
+    };
+
+    class LowOrCriticalHealthAndAndNaturesSwiftnessTrigger : public AndTrigger {
+    public:
+        LowOrCriticalHealthAndAndNaturesSwiftnessTrigger(PlayerbotAI* ai)
+            : AndTrigger(ai, new BuffCanBeCastTrigger(ai, "nature's swiftness"), new LowOrCriticalHealthTrigger(ai)) {}
+    };
+
+    class PartyMemberLowOrCriticalHealthAndNaturesSwiftnessTrigger : public AndTrigger {
+    public:
+        PartyMemberLowOrCriticalHealthAndNaturesSwiftnessTrigger(PlayerbotAI* ai)
+            : AndTrigger(ai, new BuffCanBeCastTrigger(ai, "nature's swiftness"), new PartyMemberLowOrCriticalHealthTrigger(ai)) {}
     };
 }

--- a/playerbot/strategy/druid/DruidTriggers.h
+++ b/playerbot/strategy/druid/DruidTriggers.h
@@ -161,17 +161,8 @@ namespace ai {
         BashInterruptEnemyHealerSpellTrigger(PlayerbotAI* ai) : InterruptEnemyHealerTrigger(ai, "bash") {}
     };
 
-    class NaturesSwiftnessTrigger : public BuffTrigger
-    {
-    public:
-        NaturesSwiftnessTrigger(PlayerbotAI* ai) : BuffTrigger(ai, "nature's swiftness") {}
-    };
-
-    class ForceOfNatureTrigger : public BuffTrigger
-    {
-    public:
-        ForceOfNatureTrigger(PlayerbotAI* ai) : BuffTrigger(ai, "force of nature") {}
-    };
+    BUFF_TRIGGER(NaturesSwiftnessTrigger, "nature's swiftness");
+    BUFF_TRIGGER(ForceOfNatureTrigger, "force of nature");
 
     class NourishTrigger : public BuffTrigger {
     public:
@@ -187,20 +178,14 @@ namespace ai {
         virtual bool IsActive() { return BuffOnPartyTrigger::IsActive() && ai->HasAnyAuraOf(GetTarget(), "rejuvenation", "regrowth", "lifebloom", "wild growth", NULL); }
     };
 
-    class RejuvenationHotOnPartyTrigger : public BuffOnPartyTrigger {
-    public:
-        RejuvenationHotOnPartyTrigger(PlayerbotAI* ai) : BuffOnPartyTrigger(ai, "rejuvenation") {}
-    };
+    BUFF_PARTY_TRIGGER(RejuvenationHotOnPartyTrigger, "rejuvenation");
 
     class RejuvenationHotOnTankTrigger : public BuffOnTankTrigger {
     public:
         RejuvenationHotOnTankTrigger(PlayerbotAI* ai) : BuffOnTankTrigger(ai, "rejuvenation") {}
     };
 
-    class ClearCastingTrigger : public HasAuraTrigger {
-    public:
-        ClearCastingTrigger(PlayerbotAI* ai) : HasAuraTrigger(ai, "Clearcasting") {}
-    };
+    HAS_AURA_TRIGGER(ClearCastingTrigger, "Clearcasting");
 
     class LowOrCriticalHealthAndClearCastingTrigger : public AndTrigger {
     public:

--- a/playerbot/strategy/druid/DruidTriggers.h
+++ b/playerbot/strategy/druid/DruidTriggers.h
@@ -166,4 +166,58 @@ namespace ai {
     public:
         NaturesSwiftnessTrigger(PlayerbotAI* ai) : BuffTrigger(ai, "nature's swiftness") {}
     };
+
+    class ForceOfNatureTrigger : public BuffTrigger
+    {
+    public:
+        ForceOfNatureTrigger(PlayerbotAI* ai) : BuffTrigger(ai, "force of nature") {}
+    };
+
+    class NourishTrigger : public BuffTrigger {
+    public:
+        NourishTrigger(PlayerbotAI* ai) : BuffTrigger(ai, "nourish") {}
+
+        virtual bool IsActive() {  return BuffTrigger::IsActive() && ai->HasAnyAuraOf(bot, "rejuvenation", "regrowth", "lifebloom", "wild growth", NULL);  }
+    };
+
+    class NourishOnPartyTrigger : public BuffOnPartyTrigger {
+    public:
+        NourishOnPartyTrigger(PlayerbotAI* ai) : BuffOnPartyTrigger(ai, "nourish") {}
+
+        virtual bool IsActive() { return BuffOnPartyTrigger::IsActive() && ai->HasAnyAuraOf(GetTarget(), "rejuvenation", "regrowth", "lifebloom", "wild growth", NULL); }
+    };
+
+    class NourishAndMediumHealthTrigger : public AndTrigger {
+    public:
+        NourishAndMediumHealthTrigger(PlayerbotAI* ai) : AndTrigger(ai, new NourishTrigger(ai), new MediumHealthTrigger(ai)) {}
+    };
+
+    class NourishOnPartyAndMediumHealthTrigger : public AndTrigger {
+    public:
+        NourishOnPartyAndMediumHealthTrigger(PlayerbotAI* ai) : AndTrigger(ai, new NourishOnPartyTrigger(ai), new PartyMemberMediumHealthTrigger(ai)) {}
+    };
+
+    class SwiftmendTrigger : public BuffTrigger {
+    public:
+        SwiftmendTrigger(PlayerbotAI* ai) : BuffTrigger(ai, "swiftmend") {}
+
+        virtual bool IsActive() { return ai->HasAnyAuraOf(bot, "rejuvenation", "regrowth", NULL); }
+    };
+
+    class SwiftmendOnPartyTrigger : public BuffOnPartyTrigger {
+    public:
+        SwiftmendOnPartyTrigger(PlayerbotAI* ai) : BuffOnPartyTrigger(ai, "switfmend") {}
+
+        virtual bool IsActive() { return ai->HasAnyAuraOf(GetTarget(), "rejuvenation", "regrowth", NULL); }
+    };
+
+    class SwiftmendAndLowHealthTrigger : public AndTrigger {
+    public:
+        SwiftmendAndLowHealthTrigger(PlayerbotAI* ai) : AndTrigger(ai, new SwiftmendTrigger(ai), new LowHealthTrigger(ai)) {}
+    };
+
+    class SwiftmendOnPartyAndLowHealthTrigger : public AndTrigger {
+    public:
+        SwiftmendOnPartyAndLowHealthTrigger(PlayerbotAI* ai) : AndTrigger(ai, new SwiftmendOnPartyTrigger(ai), new PartyMemberLowHealthTrigger(ai)) {}
+    };
 }

--- a/playerbot/strategy/druid/DruidTriggers.h
+++ b/playerbot/strategy/druid/DruidTriggers.h
@@ -220,4 +220,11 @@ namespace ai {
     public:
         SwiftmendOnPartyAndLowHealthTrigger(PlayerbotAI* ai) : AndTrigger(ai, new SwiftmendOnPartyTrigger(ai), new PartyMemberLowHealthTrigger(ai)) {}
     };
+
+    BUFF_PARTY_TRIGGER(RejuvenationHotOnPartyTrigger, "rejuvenation");
+
+    class RejuvenationHotOnTankTrigger : public BuffOnTankTrigger {
+    public:
+        RejuvenationHotOnTankTrigger(PlayerbotAI* ai) : BuffOnTankTrigger(ai, "rejuvenation") {}
+    };
 }

--- a/playerbot/strategy/druid/GenericDruidNonCombatStrategy.cpp
+++ b/playerbot/strategy/druid/GenericDruidNonCombatStrategy.cpp
@@ -94,6 +94,63 @@ void GenericDruidNonCombatStrategy::InitTriggers(std::list<TriggerNode*> &trigge
     triggers.push_back(new TriggerNode(
        "often",
        NextAction::array(0, new NextAction("apply oil", 1.0f), NULL)));
+
+
+    // healing
+    {
+        triggers.push_back(new TriggerNode(
+            "party member almost full health",
+            NextAction::array(0, new NextAction("rejuvenation on party", ACTION_LIGHT_HEAL + 1), NULL)));
+
+        // rejuv ourself on any dmg
+        triggers.push_back(new TriggerNode(
+            "almost full health",
+            NextAction::array(0, new NextAction("rejuvenation", ACTION_LIGHT_HEAL + 2), NULL)));
+
+        triggers.push_back(new TriggerNode(
+            "party member medium health",
+            NextAction::array(0, new NextAction("regrowth on party", ACTION_LIGHT_HEAL + 3), NULL)));
+
+        triggers.push_back(new TriggerNode(
+            "medium health",
+            NextAction::array(0, new NextAction("regrowth", ACTION_LIGHT_HEAL + 4), NULL)));
+
+        triggers.push_back(new TriggerNode(
+            "party member medium health",
+            NextAction::array(0, new NextAction("healing touch on party", ACTION_LIGHT_HEAL + 3), NULL)));
+
+        triggers.push_back(new TriggerNode(
+            "medium health",
+            NextAction::array(0, new NextAction("healing touch", ACTION_LIGHT_HEAL + 4), NULL)));
+
+        triggers.push_back(new TriggerNode(
+            "medium aoe heal",
+            NextAction::array(0, new NextAction("wild growth", ACTION_LIGHT_HEAL + 5), NULL)));
+
+        triggers.push_back(new TriggerNode(
+            "party member low health",
+            NextAction::array(0, new NextAction("healing touch on party", ACTION_LIGHT_HEAL + 7), new NextAction("regrowth on party", ACTION_LIGHT_HEAL + 6), NULL)));
+
+        triggers.push_back(new TriggerNode(
+            "low health",
+            NextAction::array(0, new NextAction("healing touch", ACTION_LIGHT_HEAL + 9), new NextAction("regrowth", ACTION_LIGHT_HEAL + 8), NULL)));
+
+        triggers.push_back(new TriggerNode(
+            "low aoe heal",
+            NextAction::array(0, new NextAction("wild growth", ACTION_LIGHT_HEAL + 10), NULL)));
+
+        triggers.push_back(new TriggerNode(
+            "party member critical health",
+            NextAction::array(0, new NextAction("healing touch on party", ACTION_MEDIUM_HEAL + 7), new NextAction("regrowth on party", ACTION_MEDIUM_HEAL + 6), NULL)));
+
+        triggers.push_back(new TriggerNode(
+            "critical health",
+            NextAction::array(0, new NextAction("healing touch", ACTION_MEDIUM_HEAL + 9), new NextAction("regrowth", ACTION_MEDIUM_HEAL + 8), NULL)));
+
+        triggers.push_back(new TriggerNode(
+            "critical aoe heal",
+            NextAction::array(0, new NextAction("tranquility", ACTION_MEDIUM_HEAL + 10), NULL)));
+    }
 }
 
 GenericDruidBuffStrategy::GenericDruidBuffStrategy(PlayerbotAI* ai) : NonCombatStrategy(ai)

--- a/playerbot/strategy/druid/GenericDruidNonCombatStrategy.cpp
+++ b/playerbot/strategy/druid/GenericDruidNonCombatStrategy.cpp
@@ -128,24 +128,16 @@ void GenericDruidNonCombatStrategy::InitTriggers(std::list<TriggerNode*> &trigge
             NextAction::array(0, new NextAction("wild growth", ACTION_LIGHT_HEAL + 5), NULL)));
 
         triggers.push_back(new TriggerNode(
-            "party member low health",
+            "party member low or critical health",
             NextAction::array(0, new NextAction("healing touch on party", ACTION_LIGHT_HEAL + 7), new NextAction("regrowth on party", ACTION_LIGHT_HEAL + 6), NULL)));
 
         triggers.push_back(new TriggerNode(
-            "low health",
+            "low or critical health",
             NextAction::array(0, new NextAction("healing touch", ACTION_LIGHT_HEAL + 9), new NextAction("regrowth", ACTION_LIGHT_HEAL + 8), NULL)));
 
         triggers.push_back(new TriggerNode(
             "low aoe heal",
             NextAction::array(0, new NextAction("wild growth", ACTION_LIGHT_HEAL + 10), NULL)));
-
-        triggers.push_back(new TriggerNode(
-            "party member critical health",
-            NextAction::array(0, new NextAction("healing touch on party", ACTION_MEDIUM_HEAL + 7), new NextAction("regrowth on party", ACTION_MEDIUM_HEAL + 6), NULL)));
-
-        triggers.push_back(new TriggerNode(
-            "critical health",
-            NextAction::array(0, new NextAction("healing touch", ACTION_MEDIUM_HEAL + 9), new NextAction("regrowth", ACTION_MEDIUM_HEAL + 8), NULL)));
 
         triggers.push_back(new TriggerNode(
             "critical aoe heal",

--- a/playerbot/strategy/druid/GenericDruidStrategy.cpp
+++ b/playerbot/strategy/druid/GenericDruidStrategy.cpp
@@ -96,25 +96,25 @@ void GenericDruidStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
 {
     CombatStrategy::InitTriggers(triggers);
 
-    triggers.push_back(new TriggerNode(
+    /*triggers.push_back(new TriggerNode(
         "low health",
         NextAction::array(0, new NextAction("regrowth", ACTION_MEDIUM_HEAL + 2), NULL)));
 
     triggers.push_back(new TriggerNode(
         "party member low health",
-        NextAction::array(0, new NextAction("regrowth on party", ACTION_MEDIUM_HEAL + 1), NULL)));
+        NextAction::array(0, new NextAction("regrowth on party", ACTION_MEDIUM_HEAL + 1), NULL)));*/
 
     triggers.push_back(new TriggerNode(
         "medium health",
         NextAction::array(0, new NextAction("barkskin", ACTION_EMERGENCY + 1), NULL)));
 
-    triggers.push_back(new TriggerNode(
+    /*triggers.push_back(new TriggerNode(
         "critical health",
         NextAction::array(0, new NextAction("regrowth", ACTION_CRITICAL_HEAL + 2), new NextAction("healing touch", ACTION_CRITICAL_HEAL + 2), NULL)));
 
     triggers.push_back(new TriggerNode(
         "party member critical health",
-        NextAction::array(0,  new NextAction("regrowth on party", ACTION_CRITICAL_HEAL + 1), new NextAction("healing touch on party", ACTION_CRITICAL_HEAL + 1), NULL)));
+        NextAction::array(0,  new NextAction("regrowth on party", ACTION_CRITICAL_HEAL + 1), new NextAction("healing touch on party", ACTION_CRITICAL_HEAL + 1), NULL)));*/
 
 	triggers.push_back(new TriggerNode(
 		"party member dead",
@@ -138,9 +138,15 @@ void DruidCureStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
 
 void DruidBoostStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
 {
+    // TODO: maybe remove this and control it more explcitly
     triggers.push_back(new TriggerNode(
         "nature's swiftness",
         NextAction::array(0, new NextAction("nature's swiftness", ACTION_HIGH + 9), NULL)));
+
+    // TODO: talk with robi, if this should be a caster form only skill & maybe not used, since it will taunt
+    triggers.push_back(new TriggerNode(
+        "force of nature",
+        NextAction::array(0, new NextAction("force of nature", ACTION_HIGH + 10), NULL)));
 }
 
 void DruidCcStrategy::InitTriggers(std::list<TriggerNode*> &triggers)

--- a/playerbot/strategy/druid/GenericDruidStrategy.cpp
+++ b/playerbot/strategy/druid/GenericDruidStrategy.cpp
@@ -104,6 +104,9 @@ void GenericDruidStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
         "party member low health",
         NextAction::array(0, new NextAction("regrowth on party", ACTION_MEDIUM_HEAL + 1), NULL)));
 
+    triggers.push_back(new TriggerNode(
+        "medium health",
+        NextAction::array(0, new NextAction("barkskin", ACTION_EMERGENCY + 1), NULL)));
 
     triggers.push_back(new TriggerNode(
         "critical health",
@@ -112,7 +115,6 @@ void GenericDruidStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
     triggers.push_back(new TriggerNode(
         "party member critical health",
         NextAction::array(0,  new NextAction("regrowth on party", ACTION_CRITICAL_HEAL + 1), new NextAction("healing touch on party", ACTION_CRITICAL_HEAL + 1), NULL)));
-
 
 	triggers.push_back(new TriggerNode(
 		"party member dead",

--- a/playerbot/strategy/druid/GenericDruidStrategy.cpp
+++ b/playerbot/strategy/druid/GenericDruidStrategy.cpp
@@ -138,10 +138,10 @@ void DruidCureStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
 
 void DruidBoostStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
 {
-    // TODO: maybe remove this and control it more explcitly
-    triggers.push_back(new TriggerNode(
-        "nature's swiftness",
-        NextAction::array(0, new NextAction("nature's swiftness", ACTION_HIGH + 9), NULL)));
+    //// removed this, since we want to contrl the swiftness in healing druid variant
+    //triggers.push_back(new TriggerNode(
+    //    "nature's swiftness",
+    //    NextAction::array(0, new NextAction("nature's swiftness", ACTION_HIGH + 9), NULL)));
 
     // TODO: talk with robi, if this should be a caster form only skill & maybe not used, since it will taunt
     triggers.push_back(new TriggerNode(

--- a/playerbot/strategy/druid/GenericDruidStrategy.cpp
+++ b/playerbot/strategy/druid/GenericDruidStrategy.cpp
@@ -96,25 +96,25 @@ void GenericDruidStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
 {
     CombatStrategy::InitTriggers(triggers);
 
-    /*triggers.push_back(new TriggerNode(
+    triggers.push_back(new TriggerNode(
         "low health",
         NextAction::array(0, new NextAction("regrowth", ACTION_MEDIUM_HEAL + 2), NULL)));
 
     triggers.push_back(new TriggerNode(
         "party member low health",
-        NextAction::array(0, new NextAction("regrowth on party", ACTION_MEDIUM_HEAL + 1), NULL)));*/
+        NextAction::array(0, new NextAction("regrowth on party", ACTION_MEDIUM_HEAL + 1), NULL)));
 
     triggers.push_back(new TriggerNode(
         "medium health",
         NextAction::array(0, new NextAction("barkskin", ACTION_EMERGENCY + 1), NULL)));
 
-    /*triggers.push_back(new TriggerNode(
+    triggers.push_back(new TriggerNode(
         "critical health",
         NextAction::array(0, new NextAction("regrowth", ACTION_CRITICAL_HEAL + 2), new NextAction("healing touch", ACTION_CRITICAL_HEAL + 2), NULL)));
 
     triggers.push_back(new TriggerNode(
         "party member critical health",
-        NextAction::array(0,  new NextAction("regrowth on party", ACTION_CRITICAL_HEAL + 1), new NextAction("healing touch on party", ACTION_CRITICAL_HEAL + 1), NULL)));*/
+        NextAction::array(0,  new NextAction("regrowth on party", ACTION_CRITICAL_HEAL + 1), new NextAction("healing touch on party", ACTION_CRITICAL_HEAL + 1), NULL)));
 
 	triggers.push_back(new TriggerNode(
 		"party member dead",

--- a/playerbot/strategy/druid/HealDruidStrategy.cpp
+++ b/playerbot/strategy/druid/HealDruidStrategy.cpp
@@ -24,16 +24,16 @@ HealDruidStrategy::HealDruidStrategy(PlayerbotAI* ai) : GenericDruidStrategy(ai)
 *  (DONE) - use 'tree of life' initially on fight
 *  (DONE) - use 'rejuvenation' when the anyone including you has lost any hp
 *  (DONE) [MAYBE 2 MUCH IN RAID?, TANK IS ENOUGH]- use 'rejuvenation' when the fight has started on as much party players as possible (no need to know their dmg) [no aura]
-*  (TODO) - use 'wild growth' whenever any party member has lost any hp (can be started on fight start till end) [almost full]
-*  (TODO) - use 'regrowth' when no regrowth buff is applied and you or anyone hast lost any spell
-*  (TODO) - use 'regrowth', when nourish is not working and heal + restart hot
-*  (TODO) - use 'nourish', when hp has been lost "a bit more than almost full" AND an auro of type lifebloom, rejuvenation, regrowth or wild growth is active
-*  (TODO) - use 'barkskin' when on medium hp, or when a huge thread cast like 'tranquily' is about to be used
-*  (TODO) - use 'swiftmend' when someon is at low hp
-*  (TODO) - use 'healing touch' ONLY, when it can be casted instantly and someone is at least at medium health
-*  (TODO) - use 'tranquily' only, when whole party (group or raid) is at low hp
-*  (TODO) - use 'nature's swiftness' when someone is at critical health combined with 'healing touch'
-*  (TODO) - use 'lifebloom', when 'cleacasting' is available, and noone is lower than medium health (regain mana later)
+*  (DONE) - use 'wild growth' whenever any party member has lost any hp (can be started on fight start till end) [almost full]
+*  (DONE) - use 'regrowth' when no regrowth buff is applied and you or anyone hast lost any spell
+*  (DONE) - use 'regrowth', when nourish is not working and heal + restart hot
+*  (DONE) - use 'nourish', when hp has been lost "a bit more than almost full" AND an auro of type lifebloom, rejuvenation, regrowth or wild growth is active
+*  (DONE) - use 'barkskin' when on medium hp, or when a huge thread cast like 'tranquily' is about to be used
+*  (DONE) - use 'swiftmend' when someon is at low hp
+*  (DONE) - use 'healing touch' ONLY, when it can be casted instantly and someone is at least at medium health
+*  (DONE) - use 'tranquility' only, when whole party (group or raid) is at low hp
+*  (DONE) - use 'nature's swiftness' when someone is at critical health combined with 'healing touch'
+*  (DONE) - use 'lifebloom', when 'cleacasting' is available, and noone is lower than medium health (regain mana later)
 *  (TODO) - use 'lifebloom' on maintank on big encounters and stack it to 3 (+ holding it when it is nearly about to end) OR get mana back and end
 *  (DONE) - use 'innervate' when on low mana
 *  (TODO) - use 'innervate' when someone else by importance is at low mana (main healer?)
@@ -91,48 +91,84 @@ void HealDruidStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
 
         //  apply nourish, whenever anyone is at medium health and has a druidHoT (regrowth, rejuv, lifebloom, wildgrowth) available
         triggers.push_back(new TriggerNode(
-            "nourish on party",
+            "party member medium health",
             NextAction::array(0, new NextAction("nourish on party", ACTION_MEDIUM_HEAL + 3), NULL)));
 
         triggers.push_back(new TriggerNode(
-            "nourish",
+            "medium health",
             NextAction::array(0, new NextAction("nourish", ACTION_MEDIUM_HEAL + 4), NULL)));
+
+        triggers.push_back(new TriggerNode(
+            "party member medium health",
+            NextAction::array(0, new NextAction("refresh regrowth on party", ACTION_MEDIUM_HEAL + 5), NULL)));
+
+        triggers.push_back(new TriggerNode(
+            "medium health",
+            NextAction::array(0, new NextAction("refresh regrowth", ACTION_MEDIUM_HEAL + 6), NULL)));
+
+        triggers.push_back(new TriggerNode(
+            "medium health",
+            NextAction::array(0, new NextAction("instant lifebloom", ACTION_MEDIUM_HEAL + 7), NULL)));
     }
 
     // critical section
     {
         // cast wildgrowth when: in a party & whenever available & anyone lost any portion of hp
         triggers.push_back(new TriggerNode(
-            "party member almost full health",
-            NextAction::array(0, new NextAction("wild growth on party", ACTION_CRITICAL_HEAL + 2), NULL)));
+            "almost full aoe heal",
+            NextAction::array(0, new NextAction("wild growth", ACTION_CRITICAL_HEAL), NULL)));
 
         // add swiftmend, whenever anyone is at medium health and has a druid (regrowth, rejuv, wildgrowth)
         triggers.push_back(new TriggerNode(
-            "swiftmend on party",
-            NextAction::array(0, new NextAction("swiftmend on party", ACTION_CRITICAL_HEAL + 4), NULL)));
-        triggers.push_back(new TriggerNode(
-            "swiftmend",
-            NextAction::array(0, new NextAction("swiftmend", ACTION_CRITICAL_HEAL + 5), NULL)));
+            "party member low health",
+            NextAction::array(0, new NextAction("swiftmend on party", ACTION_CRITICAL_HEAL + 1), NULL)));
 
         triggers.push_back(new TriggerNode(
-            "critical aoe heal",
-            NextAction::array(0, new NextAction("barkskin"), new NextAction("tranquility", ACTION_CRITICAL_HEAL + 8), NULL)));
+            "low health",
+            NextAction::array(0, new NextAction("swiftmend", ACTION_CRITICAL_HEAL + 2), NULL)));
 
-        // TODO: cast nature's swiftness + healing touch on critical health of any player
+        triggers.push_back(new TriggerNode(
+            "party member critical health",
+            NextAction::array(0, new NextAction("nature's swiftness", ACTION_CRITICAL_HEAL + 4), new NextAction("healing touch on party", ACTION_CRITICAL_HEAL + 3), NULL)));
+
+        triggers.push_back(new TriggerNode(
+            "critical health",
+            NextAction::array(0, new NextAction("nature's swiftness", ACTION_CRITICAL_HEAL + 6), new NextAction("healing touch", ACTION_CRITICAL_HEAL + 5), NULL)));
+
+        triggers.push_back(new TriggerNode(
+            "party member critical health",
+            NextAction::array(0, new NextAction("swiftmend on party", ACTION_CRITICAL_HEAL + 7), NULL)));
+
+        triggers.push_back(new TriggerNode(
+            "critical health",
+            NextAction::array(0, new NextAction("swiftmend", ACTION_CRITICAL_HEAL + 8), NULL)));
+
+        triggers.push_back(new TriggerNode(
+            "party member critical health",
+            NextAction::array(0, new NextAction("instant healing touch on party", ACTION_CRITICAL_HEAL + 9), NULL)));
+
+        triggers.push_back(new TriggerNode(
+            "critical health",
+            NextAction::array(0, new NextAction("instant healing touch", ACTION_CRITICAL_HEAL + 10), NULL)));
     }
 
     // emergencies
     {
+
+        triggers.push_back(new TriggerNode(
+            "critical aoe heal",
+            NextAction::array(0, new NextAction("tranquility", ACTION_EMERGENCY), NULL)));
+
         triggers.push_back(new TriggerNode(
             "tree form",
-            NextAction::array(0, new NextAction("tree form", ACTION_EMERGENCY), NULL)));
+            NextAction::array(0, new NextAction("tree form", ACTION_EMERGENCY + 10), NULL)));
 
         triggers.push_back(new TriggerNode(
             "medium health",
-            NextAction::array(0, new NextAction("barkskin", ACTION_EMERGENCY + 1), NULL)));
+            NextAction::array(0, new NextAction("barkskin", ACTION_EMERGENCY + 11), NULL)));
 
         triggers.push_back(new TriggerNode(
             "low mana",
-            NextAction::array(0, new NextAction("innervate", ACTION_EMERGENCY + 5), NULL)));
+            NextAction::array(0, new NextAction("innervate", ACTION_EMERGENCY + 15), NULL)));
     }
 }

--- a/playerbot/strategy/druid/HealDruidStrategy.cpp
+++ b/playerbot/strategy/druid/HealDruidStrategy.cpp
@@ -28,12 +28,13 @@ HealDruidStrategy::HealDruidStrategy(PlayerbotAI* ai) : GenericDruidStrategy(ai)
 *  (DONE) - use 'regrowth' when no regrowth buff is applied and you or anyone hast lost any spell
 *  (DONE) - use 'regrowth', when nourish is not working and heal + restart hot
 *  (DONE) - use 'nourish', when hp has been lost "a bit more than almost full" AND an auro of type lifebloom, rejuvenation, regrowth or wild growth is active
-*  (DONE) - use 'barkskin' when on medium hp, or when a huge thread cast like 'tranquily' is about to be used
+*  (DONE) - use 'barkskin' when on medium hp
+*  (TODO) - use 'barkskin' when a huge thread cast like 'tranquily' is about to be used
 *  (DONE) - use 'swiftmend' when someon is at low hp
 *  (DONE) - use 'healing touch' ONLY, when it can be casted instantly and someone is at least at medium health
 *  (DONE) - use 'tranquility' only, when whole party (group or raid) is at low hp
 *  (DONE) - use 'nature's swiftness' when someone is at critical health combined with 'healing touch'
-*  (DONE) - use 'lifebloom', when 'cleacasting' is available, and noone is lower than medium health (regain mana later)
+*  (TODO) - use 'lifebloom', when 'cleacasting' is available, and noone is lower than medium health (regain mana later)
 *  (TODO) - use 'lifebloom' on maintank on big encounters and stack it to 3 (+ holding it when it is nearly about to end) OR get mana back and end
 *  (DONE) - use 'innervate' when on low mana
 *  (TODO) - use 'innervate' when someone else by importance is at low mana (main healer?)
@@ -59,6 +60,18 @@ void HealDruidStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
         triggers.push_back(new TriggerNode(
             "party member to heal out of spell range",
             NextAction::array(0, new NextAction("reach party member to heal", ACTION_CRITICAL_HEAL + 1), NULL)));
+
+        triggers.push_back(new TriggerNode(
+            "medium health",
+            NextAction::array(0, new NextAction("barkskin", ACTION_EMERGENCY + 10), NULL)));
+
+        triggers.push_back(new TriggerNode(
+            "low mana",
+            NextAction::array(0, new NextAction("innervate", ACTION_EMERGENCY + 15), NULL)));
+
+        triggers.push_back(new TriggerNode(
+            "tree form",
+            NextAction::array(0, new NextAction("tree form", ACTION_EMERGENCY + 20), NULL)));
     }
 
     // low section
@@ -111,28 +124,20 @@ void HealDruidStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
     {
         // add swiftmend, whenever anyone is at medium health and has a druid (regrowth, rejuv, wildgrowth)
         triggers.push_back(new TriggerNode(
-            "party member low health",
+            "party member low or critical health",
             NextAction::array(0, new NextAction("swiftmend on party", ACTION_CRITICAL_HEAL + 1), NULL)));
 
         triggers.push_back(new TriggerNode(
-            "low health",
+            "low or critical health",
             NextAction::array(0, new NextAction("swiftmend", ACTION_CRITICAL_HEAL + 2), NULL)));
 
         triggers.push_back(new TriggerNode(
-            "party member critical health",
+            "party member low or critical health and natures swiftness",
             NextAction::array(0, new NextAction("nature's swiftness", ACTION_CRITICAL_HEAL + 4), new NextAction("healing touch on party", ACTION_CRITICAL_HEAL + 3), NULL)));
 
         triggers.push_back(new TriggerNode(
-            "critical health",
+            "low or critical health and natures swiftness",
             NextAction::array(0, new NextAction("nature's swiftness", ACTION_CRITICAL_HEAL + 6), new NextAction("healing touch", ACTION_CRITICAL_HEAL + 5), NULL)));
-
-        triggers.push_back(new TriggerNode(
-            "party member critical health",
-            NextAction::array(0, new NextAction("swiftmend on party", ACTION_CRITICAL_HEAL + 7), NULL)));
-
-        triggers.push_back(new TriggerNode(
-            "critical health",
-            NextAction::array(0, new NextAction("swiftmend", ACTION_CRITICAL_HEAL + 8), NULL)));
 
         // cast wildgrowth when: in a party & whenever available & anyone lost any portion of hp
         triggers.push_back(new TriggerNode(
@@ -156,33 +161,16 @@ void HealDruidStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
             "critical aoe heal",
             NextAction::array(0, new NextAction("tranquility", ACTION_EMERGENCY), NULL)));
 
-        triggers.push_back(new TriggerNode(
-            "medium health",
-            NextAction::array(0, new NextAction("instant lifebloom", ACTION_EMERGENCY + 1), NULL)));
+        //triggers.push_back(new TriggerNode(
+        //    "clearcasting",
+        //    NextAction::array(0, new NextAction("lifebloom", ACTION_EMERGENCY + 2), NULL)));
 
         triggers.push_back(new TriggerNode(
-            "party member medium health",
-            NextAction::array(0, new NextAction("instant lifebloom on party", ACTION_EMERGENCY + 2), NULL)));
+            "party member low or critical health and clearcasting",
+            NextAction::array(0, new NextAction("healing touch on party", ACTION_EMERGENCY + 3), NULL)));
 
         triggers.push_back(new TriggerNode(
-            "party member critical health",
-            NextAction::array(0, new NextAction("instant healing touch on party", ACTION_EMERGENCY + 3), NULL)));
-
-        triggers.push_back(new TriggerNode(
-            "critical health",
-            NextAction::array(0, new NextAction("instant healing touch", ACTION_EMERGENCY + 4), NULL)));
-
-
-        triggers.push_back(new TriggerNode(
-            "tree form",
-            NextAction::array(0, new NextAction("tree form", ACTION_EMERGENCY + 10), NULL)));
-
-        triggers.push_back(new TriggerNode(
-            "medium health",
-            NextAction::array(0, new NextAction("barkskin", ACTION_EMERGENCY + 11), NULL)));
-
-        triggers.push_back(new TriggerNode(
-            "low mana",
-            NextAction::array(0, new NextAction("innervate", ACTION_EMERGENCY + 15), NULL)));
+            "low or critical health and clearcasting",
+            NextAction::array(0, new NextAction("healing touch", ACTION_EMERGENCY + 4), NULL)));
     }
 }

--- a/playerbot/strategy/druid/HealDruidStrategy.cpp
+++ b/playerbot/strategy/druid/HealDruidStrategy.cpp
@@ -19,20 +19,61 @@ HealDruidStrategy::HealDruidStrategy(PlayerbotAI* ai) : GenericDruidStrategy(ai)
     actionNodeFactories.Add(new HealDruidStrategyActionNodeFactory());
 }
 
+/*
+* The healing druid has the following main rotation
+*  (DONE) - use 'tree of life' initially on fight
+*  (DONE) - use 'rejuvenation' when the anyone including you has lost any hp
+*  (DONE) [MAYBE 2 MUCH IN RAID?, TANK IS ENOUGH]- use 'rejuvenation' when the fight has started on as much party players as possible (no need to know their dmg) [no aura]
+*  (TODO) - use 'wild growth' whenever any party member has lost any hp (can be started on fight start till end) [almost full]
+*  (TODO) - use 'regrowth' when no regrowth buff is applied and you or anyone hast lost any spell
+*  (TODO) - use 'regrowth', when nourish is not working and heal + restart hot
+*  (TODO) - use 'nourish', when hp has been lost "a bit more than almost full" AND an auro of type lifebloom, rejuvenation, regrowth or wild growth is active
+*  (TODO) - use 'barkskin' when on medium hp, or when a huge thread cast like 'tranquily' is about to be used
+*  (TODO) - use 'swiftmend' when someon is at low hp
+*  (TODO) - use 'healing touch' ONLY, when it can be casted instantly and someone is at least at medium health
+*  (TODO) - use 'tranquily' only, when whole party (group or raid) is at low hp
+*  (TODO) - use 'nature's swiftness' when someone is at critical health combined with 'healing touch'
+*  (TODO) - use 'lifebloom', when 'cleacasting' is available, and noone is lower than medium health (regain mana later)
+*  (TODO) - use 'lifebloom' on maintank on big encounters and stack it to 3 (+ holding it when it is nearly about to end) OR get mana back and end
+*  (DONE) - use 'innervate' when on low mana
+*  (TODO) - use 'innervate' when someone else by importance is at low mana (main healer?)
+*  (DONE) - use 'rebirth' when someone died in battle (maybe bad to have this automatically - let human decide this??)
+*  (TODO) - use 'rebirth' when someone of importance died in battle (tank, main healer) (maybe human player?)
+*/
 void HealDruidStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
 {
-    GenericDruidStrategy::InitTriggers(triggers);
+    // we skip the generic druid
+    //GenericDruidStrategy::InitTriggers(triggers);
+    CombatStrategy::InitTriggers(triggers);
 
-    // low section
+    // non healing related actions
     {
         triggers.push_back(new TriggerNode(
             "enemy out of spell",
             NextAction::array(0, new NextAction("reach spell", ACTION_NORMAL + 9), NULL)));
 
         triggers.push_back(new TriggerNode(
+            "party member dead",
+            NextAction::array(0, new NextAction("rebirth", ACTION_HIGH + 1), NULL)));
+
+        triggers.push_back(new TriggerNode(
+            "party member to heal out of spell range",
+            NextAction::array(0, new NextAction("reach party member to heal", ACTION_CRITICAL_HEAL + 1), NULL)));
+    }
+
+    // low section
+    {
+        // apply rejuv hot on tank
+        triggers.push_back(new TriggerNode(
+            "rejuvenation hot on tank",
+            NextAction::array(0, new NextAction("rejuvenation hot on party", ACTION_LIGHT_HEAL), NULL)));
+
+        // rejuv on any bit of dmg applied to party member
+        triggers.push_back(new TriggerNode(
             "party member almost full health",
             NextAction::array(0, new NextAction("rejuvenation on party", ACTION_LIGHT_HEAL + 1), NULL)));
 
+        // rejuv ourself on any dmg
         triggers.push_back(new TriggerNode(
             "almost full health",
             NextAction::array(0, new NextAction("rejuvenation", ACTION_LIGHT_HEAL + 2), NULL)));
@@ -56,16 +97,10 @@ void HealDruidStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
         triggers.push_back(new TriggerNode(
             "nourish",
             NextAction::array(0, new NextAction("nourish", ACTION_MEDIUM_HEAL + 4), NULL)));
-
-        // TODO: cast lifebloom on free isntant cast on medium or low health unit
     }
 
     // critical section
     {
-        triggers.push_back(new TriggerNode(
-            "party member to heal out of spell range",
-            NextAction::array(0, new NextAction("reach party member to heal", ACTION_CRITICAL_HEAL + 1), NULL)));
-
         // cast wildgrowth when: in a party & whenever available & anyone lost any portion of hp
         triggers.push_back(new TriggerNode(
             "party member almost full health",
@@ -83,7 +118,6 @@ void HealDruidStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
             "critical aoe heal",
             NextAction::array(0, new NextAction("barkskin"), new NextAction("tranquility", ACTION_CRITICAL_HEAL + 8), NULL)));
 
-
         // TODO: cast nature's swiftness + healing touch on critical health of any player
     }
 
@@ -92,5 +126,13 @@ void HealDruidStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
         triggers.push_back(new TriggerNode(
             "tree form",
             NextAction::array(0, new NextAction("tree form", ACTION_EMERGENCY), NULL)));
+
+        triggers.push_back(new TriggerNode(
+            "medium health",
+            NextAction::array(0, new NextAction("barkskin", ACTION_EMERGENCY + 1), NULL)));
+
+        triggers.push_back(new TriggerNode(
+            "low mana",
+            NextAction::array(0, new NextAction("innervate", ACTION_EMERGENCY + 5), NULL)));
     }
 }

--- a/playerbot/strategy/druid/HealDruidStrategy.cpp
+++ b/playerbot/strategy/druid/HealDruidStrategy.cpp
@@ -23,35 +23,74 @@ void HealDruidStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
 {
     GenericDruidStrategy::InitTriggers(triggers);
 
-    triggers.push_back(new TriggerNode(
-        "enemy out of spell",
-        NextAction::array(0, new NextAction("reach spell", ACTION_NORMAL + 9), NULL)));
+    // low section
+    {
+        triggers.push_back(new TriggerNode(
+            "enemy out of spell",
+            NextAction::array(0, new NextAction("reach spell", ACTION_NORMAL + 9), NULL)));
 
-    triggers.push_back(new TriggerNode(
-        "tree form",
-        NextAction::array(0, new NextAction("tree form", ACTION_HIGH + 1), NULL)));
+        triggers.push_back(new TriggerNode(
+            "party member almost full health",
+            NextAction::array(0, new NextAction("rejuvenation on party", ACTION_LIGHT_HEAL + 1), NULL)));
 
-    triggers.push_back(new TriggerNode(
-        "medium health",
-        NextAction::array(0, new NextAction("regrowth", ACTION_MEDIUM_HEAL + 2), NULL)));
+        triggers.push_back(new TriggerNode(
+            "almost full health",
+            NextAction::array(0, new NextAction("rejuvenation", ACTION_LIGHT_HEAL + 2), NULL)));
+    }
 
-    triggers.push_back(new TriggerNode(
-        "party member medium health",
-        NextAction::array(0, new NextAction("regrowth on party", ACTION_MEDIUM_HEAL + 1), NULL)));
+    // normal section
+    {
+        triggers.push_back(new TriggerNode(
+            "party member medium health",
+            NextAction::array(0, new NextAction("regrowth on party", ACTION_MEDIUM_HEAL + 1), NULL)));
 
-    triggers.push_back(new TriggerNode(
-        "almost full health",
-        NextAction::array(0, new NextAction("rejuvenation", ACTION_LIGHT_HEAL + 2), NULL)));
+        triggers.push_back(new TriggerNode(
+            "medium health",
+            NextAction::array(0, new NextAction("regrowth", ACTION_MEDIUM_HEAL + 2), NULL)));
 
-    triggers.push_back(new TriggerNode(
-        "party member almost full health",
-        NextAction::array(0, new NextAction("rejuvenation on party", ACTION_LIGHT_HEAL + 1), NULL)));
+        //  apply nourish, whenever anyone is at medium health and has a druidHoT (regrowth, rejuv, lifebloom, wildgrowth) available
+        triggers.push_back(new TriggerNode(
+            "nourish on party",
+            NextAction::array(0, new NextAction("nourish on party", ACTION_MEDIUM_HEAL + 3), NULL)));
 
-    triggers.push_back(new TriggerNode(
-        "medium aoe heal",
-        NextAction::array(0, new NextAction("tranquility", ACTION_MEDIUM_HEAL + 3), NULL)));
+        triggers.push_back(new TriggerNode(
+            "nourish",
+            NextAction::array(0, new NextAction("nourish", ACTION_MEDIUM_HEAL + 4), NULL)));
 
-    triggers.push_back(new TriggerNode(
-        "party member to heal out of spell range",
-        NextAction::array(0, new NextAction("reach party member to heal", ACTION_CRITICAL_HEAL + 1), NULL)));
+        // TODO: cast lifebloom on free isntant cast on medium or low health unit
+    }
+
+    // critical section
+    {
+        triggers.push_back(new TriggerNode(
+            "party member to heal out of spell range",
+            NextAction::array(0, new NextAction("reach party member to heal", ACTION_CRITICAL_HEAL + 1), NULL)));
+
+        // cast wildgrowth when: in a party & whenever available & anyone lost any portion of hp
+        triggers.push_back(new TriggerNode(
+            "party member almost full health",
+            NextAction::array(0, new NextAction("wild growth on party", ACTION_CRITICAL_HEAL + 2), NULL)));
+
+        // add swiftmend, whenever anyone is at medium health and has a druid (regrowth, rejuv, wildgrowth)
+        triggers.push_back(new TriggerNode(
+            "swiftmend on party",
+            NextAction::array(0, new NextAction("swiftmend on party", ACTION_CRITICAL_HEAL + 4), NULL)));
+        triggers.push_back(new TriggerNode(
+            "swiftmend",
+            NextAction::array(0, new NextAction("swiftmend", ACTION_CRITICAL_HEAL + 5), NULL)));
+
+        triggers.push_back(new TriggerNode(
+            "critical aoe heal",
+            NextAction::array(0, new NextAction("barkskin"), new NextAction("tranquility", ACTION_CRITICAL_HEAL + 8), NULL)));
+
+
+        // TODO: cast nature's swiftness + healing touch on critical health of any player
+    }
+
+    // emergencies
+    {
+        triggers.push_back(new TriggerNode(
+            "tree form",
+            NextAction::array(0, new NextAction("tree form", ACTION_EMERGENCY), NULL)));
+    }
 }

--- a/playerbot/strategy/druid/HealDruidStrategy.cpp
+++ b/playerbot/strategy/druid/HealDruidStrategy.cpp
@@ -70,12 +70,12 @@ void HealDruidStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
 
         // rejuv on any bit of dmg applied to party member
         triggers.push_back(new TriggerNode(
-            "party member almost full health",
+            "party member lost any health",
             NextAction::array(0, new NextAction("rejuvenation on party", ACTION_LIGHT_HEAL + 1), NULL)));
 
         // rejuv ourself on any dmg
         triggers.push_back(new TriggerNode(
-            "almost full health",
+            "lost any health",
             NextAction::array(0, new NextAction("rejuvenation", ACTION_LIGHT_HEAL + 2), NULL)));
     }
 
@@ -105,19 +105,10 @@ void HealDruidStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
         triggers.push_back(new TriggerNode(
             "medium health",
             NextAction::array(0, new NextAction("refresh regrowth", ACTION_MEDIUM_HEAL + 6), NULL)));
-
-        triggers.push_back(new TriggerNode(
-            "medium health",
-            NextAction::array(0, new NextAction("instant lifebloom", ACTION_MEDIUM_HEAL + 7), NULL)));
     }
 
     // critical section
     {
-        // cast wildgrowth when: in a party & whenever available & anyone lost any portion of hp
-        triggers.push_back(new TriggerNode(
-            "almost full aoe heal",
-            NextAction::array(0, new NextAction("wild growth", ACTION_CRITICAL_HEAL), NULL)));
-
         // add swiftmend, whenever anyone is at medium health and has a druid (regrowth, rejuv, wildgrowth)
         triggers.push_back(new TriggerNode(
             "party member low health",
@@ -143,13 +134,19 @@ void HealDruidStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
             "critical health",
             NextAction::array(0, new NextAction("swiftmend", ACTION_CRITICAL_HEAL + 8), NULL)));
 
+        // cast wildgrowth when: in a party & whenever available & anyone lost any portion of hp
         triggers.push_back(new TriggerNode(
-            "party member critical health",
-            NextAction::array(0, new NextAction("instant healing touch on party", ACTION_CRITICAL_HEAL + 9), NULL)));
-
+            "almost full aoe heal",
+            NextAction::array(0, new NextAction("wild growth", ACTION_CRITICAL_HEAL + 15), NULL)));
         triggers.push_back(new TriggerNode(
-            "critical health",
-            NextAction::array(0, new NextAction("instant healing touch", ACTION_CRITICAL_HEAL + 10), NULL)));
+            "medium aoe heal",
+            NextAction::array(0, new NextAction("wild growth", ACTION_CRITICAL_HEAL + 16), NULL)));
+        triggers.push_back(new TriggerNode(
+            "low aoe heal",
+            NextAction::array(0, new NextAction("wild growth", ACTION_CRITICAL_HEAL + 17), NULL)));
+        triggers.push_back(new TriggerNode(
+            "critical aoe heal",
+            NextAction::array(0, new NextAction("wild growth", ACTION_CRITICAL_HEAL + 18), NULL)));
     }
 
     // emergencies
@@ -158,6 +155,23 @@ void HealDruidStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
         triggers.push_back(new TriggerNode(
             "critical aoe heal",
             NextAction::array(0, new NextAction("tranquility", ACTION_EMERGENCY), NULL)));
+
+        triggers.push_back(new TriggerNode(
+            "medium health",
+            NextAction::array(0, new NextAction("instant lifebloom", ACTION_EMERGENCY + 1), NULL)));
+
+        triggers.push_back(new TriggerNode(
+            "party member medium health",
+            NextAction::array(0, new NextAction("instant lifebloom on party", ACTION_EMERGENCY + 2), NULL)));
+
+        triggers.push_back(new TriggerNode(
+            "party member critical health",
+            NextAction::array(0, new NextAction("instant healing touch on party", ACTION_EMERGENCY + 3), NULL)));
+
+        triggers.push_back(new TriggerNode(
+            "critical health",
+            NextAction::array(0, new NextAction("instant healing touch", ACTION_EMERGENCY + 4), NULL)));
+
 
         triggers.push_back(new TriggerNode(
             "tree form",

--- a/playerbot/strategy/triggers/GenericTriggers.cpp
+++ b/playerbot/strategy/triggers/GenericTriggers.cpp
@@ -187,6 +187,12 @@ bool SpellCanBeCastTrigger::IsActive()
     return target && ai->CanCastSpell(spell, target);
 }
 
+bool BuffCanBeCastTrigger::IsActive()
+{
+    Unit* target = GetTarget();
+    return target && ai->CanCastSpell(spell, target);
+}
+
 bool SpellCanBeCastInstantTrigger::IsActive()
 {
     Unit* target = GetTarget();

--- a/playerbot/strategy/triggers/GenericTriggers.cpp
+++ b/playerbot/strategy/triggers/GenericTriggers.cpp
@@ -69,7 +69,7 @@ bool OutNumberedTrigger::IsActive()
     uint32 friendPower = 200, foePower = 0;
     for (auto &attacker : ai->GetAiObjectContext()->GetValue<list<ObjectGuid> >("attackers")->Get())
     {
-     
+
         Creature* creature = ai->GetCreature(attacker);
         if (!creature)
             continue;
@@ -172,7 +172,7 @@ bool DebuffImmediateTrigger::IsActive()
 
     bool isNoDebuffActive = ai->HasAura(spell, target, false, false, 0);
     bool isMyDebuffActive = ai->HasAura(spell, target, false, true, 1);
-    
+
     return ai->CanCastSpell(spell, GetTarget()) && isNoDebuffActive || isMyDebuffActive;
 }
 
@@ -213,6 +213,19 @@ string AndTrigger::getName()
 {
     std::string name(ls->GetName());
     name = name + " and ";
+    name = name + rs->GetName();
+    return name;
+}
+
+bool OrTrigger::IsActive()
+{
+    return ls->IsActive() || rs->IsActive();
+}
+
+string OrTrigger::getName()
+{
+    std::string name(ls->GetName());
+    name = name + " or ";
     name = name + rs->GetName();
     return name;
 }
@@ -366,7 +379,7 @@ bool NotDpsTargetActiveTrigger::IsActive()
     Unit* dps = AI_VALUE(Unit*, "dps target");
     Unit* target = AI_VALUE(Unit*, "current target");
     Unit* enemy = AI_VALUE(Unit*, "enemy player target");
-    
+
     // do not switch if enemy target
     if (target && target == enemy && sServerFacade.IsAlive(target))
         return false;

--- a/playerbot/strategy/triggers/GenericTriggers.h
+++ b/playerbot/strategy/triggers/GenericTriggers.h
@@ -272,6 +272,13 @@ namespace ai
         virtual Value<Unit*>* GetTargetValue();
     };
 
+    class BuffCanBeCastTrigger : public BuffTrigger
+    {
+    public:
+        BuffCanBeCastTrigger(PlayerbotAI* ai, string spell, int checkInterval = 1, bool checkIsOwner = false)
+            : BuffTrigger(ai, spell, checkInterval, checkIsOwner) {}
+        virtual bool IsActive();
+    };
 
     class ProtectPartyMemberTrigger : public Trigger
     {

--- a/playerbot/strategy/triggers/GenericTriggers.h
+++ b/playerbot/strategy/triggers/GenericTriggers.h
@@ -418,6 +418,28 @@ namespace ai
         Trigger* rs;
     };
 
+    class OrTrigger : public Trigger
+    {
+    public:
+        OrTrigger(PlayerbotAI* ai, Trigger* ls, Trigger* rs) : Trigger(ai)
+        {
+            this->ls = ls;
+            this->rs = rs;
+        }
+        virtual ~OrTrigger()
+        {
+            delete ls;
+            delete rs;
+        }
+    public:
+        virtual bool IsActive();
+        virtual string getName();
+
+    protected:
+        Trigger* ls;
+        Trigger* rs;
+    };
+
     class SnareTargetTrigger : public DebuffTrigger
     {
     public:

--- a/playerbot/strategy/triggers/HealthTriggers.h
+++ b/playerbot/strategy/triggers/HealthTriggers.h
@@ -81,6 +81,13 @@ namespace ai
             LowHealthTrigger(ai, "almost full health", sPlayerbotAIConfig.almostFullHealth, sPlayerbotAIConfig.mediumHealth) {}
     };
 
+    class LostAnyHealthTrigger : public LowHealthTrigger
+    {
+    public:
+        LostAnyHealthTrigger(PlayerbotAI* ai) :
+            LowHealthTrigger(ai, "lost any health", 98.0f, 0.0f) {}
+    };
+
     class PartyMemberLowHealthTrigger : public HealthInRangeTrigger
     {
     public:
@@ -109,6 +116,13 @@ namespace ai
     public:
         PartyMemberAlmostFullHealthTrigger(PlayerbotAI* ai) :
             PartyMemberLowHealthTrigger(ai, "party member almost full health", sPlayerbotAIConfig.almostFullHealth,sPlayerbotAIConfig.mediumHealth) {}
+    };
+
+    class PartyMemberLostAnyHealthTrigger : public PartyMemberLowHealthTrigger
+    {
+    public:
+        PartyMemberLostAnyHealthTrigger(PlayerbotAI* ai) :
+            PartyMemberLowHealthTrigger(ai, "party member lost any health", 98.0f, 0.0f) {}
     };
 
     class PartyMemberToCancelHealthTrigger : public PartyMemberLowHealthTrigger

--- a/playerbot/strategy/triggers/HealthTriggers.h
+++ b/playerbot/strategy/triggers/HealthTriggers.h
@@ -85,7 +85,14 @@ namespace ai
     {
     public:
         LostAnyHealthTrigger(PlayerbotAI* ai) :
-            LowHealthTrigger(ai, "lost any health", 98.0f, 0.0f) {}
+            LowHealthTrigger(ai, "lost any health", sPlayerbotAIConfig.lostAnyHealth, 0.0f) {}
+    };
+
+    class LowOrCriticalHealthTrigger : public LowHealthTrigger
+    {
+    public:
+        LowOrCriticalHealthTrigger(PlayerbotAI* ai) :
+            LowHealthTrigger(ai, "low or critical health", sPlayerbotAIConfig.lowHealth, 0, false) {}
     };
 
     class PartyMemberLowHealthTrigger : public HealthInRangeTrigger
@@ -122,7 +129,14 @@ namespace ai
     {
     public:
         PartyMemberLostAnyHealthTrigger(PlayerbotAI* ai) :
-            PartyMemberLowHealthTrigger(ai, "party member lost any health", 98.0f, 0.0f) {}
+            PartyMemberLowHealthTrigger(ai, "party member lost any health", sPlayerbotAIConfig.lostAnyHealth, 0.0f) {}
+    };
+
+    class PartyMemberLowOrCriticalHealthTrigger : public PartyMemberLowHealthTrigger
+    {
+    public:
+        PartyMemberLowOrCriticalHealthTrigger(PlayerbotAI* ai) :
+            PartyMemberLowHealthTrigger(ai, "party member low or critical health", sPlayerbotAIConfig.lowHealth, 0, false) {}
     };
 
     class PartyMemberToCancelHealthTrigger : public PartyMemberLowHealthTrigger

--- a/playerbot/strategy/triggers/TriggerContext.h
+++ b/playerbot/strategy/triggers/TriggerContext.h
@@ -35,6 +35,8 @@ namespace ai
             creators["low health"] = &TriggerContext::LowHealth;
             creators["medium health"] = &TriggerContext::MediumHealth;
             creators["almost full health"] = &TriggerContext::AlmostFullHealth;
+            creators["lost any health"] = &TriggerContext::LostAnyHealth;
+            creators["low or critical health"] = &TriggerContext::LowOrCriticalHealth;
 
             creators["low mana"] = &TriggerContext::LowMana;
             creators["medium mana"] = &TriggerContext::MediumMana;
@@ -46,6 +48,8 @@ namespace ai
             creators["party member medium health"] = &TriggerContext::PartyMemberMediumHealth;
             creators["party member almost full health"] = &TriggerContext::PartyMemberAlmostFullHealth;
             creators["party member to cancel health"] = &TriggerContext::PartyMemberToCancelHealth;
+            creators["party member lost any health"] = &TriggerContext::PartyMemberLostAnyHealth;
+            creators["party member low or critical health"] = &TriggerContext::PartyMemberLowOrCriticalHealth;
 
             creators["use trinket"] = &TriggerContext::use_trinket;
             creators["damage stop"] = &TriggerContext::damage_stop;
@@ -231,6 +235,8 @@ namespace ai
         static Trigger* AlmostFullHealth(PlayerbotAI* ai) { return new AlmostFullHealthTrigger(ai); }
         static Trigger* CriticalHealth(PlayerbotAI* ai) { return new CriticalHealthTrigger(ai); }
         static Trigger* TargetCriticalHealth(PlayerbotAI* ai) { return new TargetCriticalHealthTrigger(ai); }
+        static Trigger* LowOrCriticalHealth(PlayerbotAI* ai) { return new LowOrCriticalHealthTrigger(ai); }
+        static Trigger* LostAnyHealth(PlayerbotAI* ai) { return new LostAnyHealthTrigger(ai); }
         static Trigger* LowMana(PlayerbotAI* ai) { return new LowManaTrigger(ai); }
         static Trigger* MediumMana(PlayerbotAI* ai) { return new MediumManaTrigger(ai); }
         static Trigger* HighMana(PlayerbotAI* ai) { return new HighManaTrigger(ai); }
@@ -271,6 +277,8 @@ namespace ai
         static Trigger* PartyMemberAlmostFullHealth(PlayerbotAI* ai) { return new PartyMemberAlmostFullHealthTrigger(ai); }
         static Trigger* PartyMemberToCancelHealth(PlayerbotAI* ai) { return new PartyMemberToCancelHealthTrigger(ai); }
         static Trigger* PartyMemberCriticalHealth(PlayerbotAI* ai) { return new PartyMemberCriticalHealthTrigger(ai); }
+        static Trigger* PartyMemberLowOrCriticalHealth(PlayerbotAI* ai) { return new PartyMemberLowOrCriticalHealthTrigger(ai); }
+        static Trigger* PartyMemberLostAnyHealth(PlayerbotAI* ai) { return new PartyMemberLostAnyHealthTrigger(ai); }
         static Trigger* PartyMemberHasAggro(PlayerbotAI* ai) { return new PartyMemberHasAggroTrigger(ai); }
         static Trigger* protect_party_member(PlayerbotAI* ai) { return new ProtectPartyMemberTrigger(ai); }
         static Trigger* no_pet(PlayerbotAI* ai) { return new NoPetTrigger(ai); }


### PR DESCRIPTION
Implement some fixes and improvements for restoration druid and balance druid

Resto druid:
* reimplement rotation and spell usage completely by having full control
* added missing spells (wild growth, nourish, swiftness, swiftmend, ...)
* always hot tank
* use hot spells, depending on need
* add tons of new triggers for various scenarios (general and druid specific)

balance druid;
* add starfall on aoe (starfall first than hurrican for full burst dmg)
* add force of nature on boost
* add typhoon on close range

In the end the healing druid should work better than before, since it will now use a lot of more spells and includes fixes for deadlocks in the healing rotation
stil some possible improvements, but for now it is a better state to play with